### PR TITLE
feat(benchmark-tests): stabilize hydration benchmarks

### DIFF
--- a/packages/tools/benchmark-tests/playwright.config.js
+++ b/packages/tools/benchmark-tests/playwright.config.js
@@ -14,9 +14,14 @@ export default defineConfig({
 		{
 			name: 'chromium',
 			use: { ...devices['Desktop Chrome'] },
-			launchOptions: {
-				args: ['--js-flags=--expose-gc'],
-			},
+                        launchOptions: {
+                                args: [
+                                        '--js-flags=--expose-gc',
+                                        '--disable-background-timer-throttling',
+                                        '--disable-renderer-backgrounding',
+                                        '--disable-extensions',
+                                ],
+                        },
 		},
 	],
 	webServer: {

--- a/packages/tools/benchmark-tests/tests/lib/browser.ts
+++ b/packages/tools/benchmark-tests/tests/lib/browser.ts
@@ -1,4 +1,4 @@
-import { TEST_BATCH_SIZE, TEST_ITERATIONS, TEST_TIMEOUT } from './config';
+import { TEST_BATCH_SIZE, TEST_ITERATIONS, TEST_TIMEOUT, TEST_WARMUP_ITERATIONS } from './config';
 import { testRun } from './test';
 import type { TagType } from './types';
 
@@ -14,5 +14,5 @@ export async function runBenchmark(tag: TagType, execFn: any, results: Map<TagTy
 	/**
 	 * Cut warmup iterations from the results.
 	 */
-	results.set(tag, durations.splice(1, durations.length - 1));
+	results.set(tag, durations.splice(TEST_WARMUP_ITERATIONS, durations.length - TEST_WARMUP_ITERATIONS));
 }

--- a/packages/tools/benchmark-tests/tests/lib/config.ts
+++ b/packages/tools/benchmark-tests/tests/lib/config.ts
@@ -3,6 +3,7 @@ import type { TagType } from './types';
 export const TEST_ITERATIONS = parseInt(process.env.TEST_ITERATIONS || '50', 10);
 export const TEST_BATCH_SIZE = parseInt(process.env.TEST_BATCH_SIZE || '100', 10);
 export const TEST_TIMEOUT = parseInt(process.env.TEST_TIMEOUT || '10000', 10);
+export const TEST_WARMUP_ITERATIONS = parseInt(process.env.TEST_WARMUP_ITERATIONS || '5', 10);
 export const TEST_URL = 'http://localhost:3000/test-page.html';
 
 export const TAGS = [

--- a/packages/tools/benchmark-tests/tests/lib/test.ts
+++ b/packages/tools/benchmark-tests/tests/lib/test.ts
@@ -18,6 +18,9 @@ export async function testRun({ batchSize, iterations, tag, timeout }: Params): 
 
 		function startNextHydration() {
 			if (batches.size > 0) {
+				performance.clearMarks();
+				performance.clearMeasures();
+				window.gc?.();
 				batchCounter++;
 				currentBatch = batches.values()?.next()?.value!;
 				performance.mark(`mark-append-${batchCounter}`);
@@ -70,6 +73,9 @@ export async function testRun({ batchSize, iterations, tag, timeout }: Params): 
 						measure.hydrated = performance.getEntriesByName(`hydrated-${batchCounter}`).pop()?.duration!;
 
 						removeBatch(currentBatch);
+						performance.clearMarks();
+						performance.clearMeasures();
+						window.gc?.();
 						setTimeout(startNextHydration);
 					}
 				}

--- a/packages/tools/benchmark-tests/wdio.conf.cjs
+++ b/packages/tools/benchmark-tests/wdio.conf.cjs
@@ -41,9 +41,18 @@ exports.config = {
 		{
 			maxInstances: 1,
 			browserName: 'chrome',
-			'goog:chromeOptions': {
-				args: ['--headless=new', '--disable-gpu', '--no-sandbox', '--disable-dev-shm-usage', '--js-flags=--expose-gc'],
-			},
+                        'goog:chromeOptions': {
+                                args: [
+                                        '--headless=new',
+                                        '--disable-gpu',
+                                        '--no-sandbox',
+                                        '--disable-dev-shm-usage',
+                                        '--js-flags=--expose-gc',
+                                        '--disable-background-timer-throttling',
+                                        '--disable-renderer-backgrounding',
+                                        '--disable-extensions',
+                                ],
+                        },
 		},
 	],
 	logLevel: 'silent',


### PR DESCRIPTION
## Summary
- trigger GC and clear performance marks for each batch
- allow configurable warmup iterations
- cut warmup iterations in results
- use deterministic browser flags for Playwright and WebDriver

## Testing
- `pnpm lint` *(fails: Unsafe call of an `error` type typed value)*
- `pnpm test` *(fails: Test failed. See above for more details)*

------
https://chatgpt.com/codex/tasks/task_e_6855fb4715d0832b81bc946833df6ea5