### PR TITLE
Add optional vibration detection for kol-alert

### DIFF
--- a/packages/components/src/components/alert/component.tsx
+++ b/packages/components/src/components/alert/component.tsx
@@ -20,7 +20,7 @@ export class KolAlertWc implements AlertAPI {
 	private readonly close = () => {
 		this._on?.onClose?.(new Event('Close'));
 		if (this.host) {
-			dispatchDomEvent(this.host, KolEvent.close);
+			dispatchDomEvent(this.host as HTMLElement, KolEvent.close);
 		}
 	};
 

--- a/packages/components/src/functional-components/Alert/Alert.tsx
+++ b/packages/components/src/functional-components/Alert/Alert.tsx
@@ -15,6 +15,31 @@ export type KolAlertFcProps = JSXBase.HTMLAttributes<HTMLDivElement> &
 		onAlertTimeout?: () => void;
 	};
 
+/**
+ * - https://developer.mozilla.org/de/docs/Web/API/Navigator/vibrate
+ * - https://googlechrome.github.io/samples/vibration/
+ * - Ongoing discussion: https://github.com/public-ui/kolibri/issues/7191
+ * @todo Move side-effect out of render-function to avoid multiple incarnations.
+ */
+const vibrateOnError = (): void => {
+	if (typeof navigator === 'undefined' || typeof navigator.vibrate !== 'function') {
+		return;
+	}
+	const ua = navigator.userActivation;
+	const hasGesture = ua?.isActive || ua?.hasBeenActive;
+	if (!hasGesture) {
+		return;
+	}
+	if (!matchMedia('(any-pointer: coarse)').matches) {
+		return;
+	}
+	try {
+		navigator.vibrate([100, 75, 100, 75, 100]);
+	} catch {
+		/* no-op */
+	}
+};
+
 const KolAlertFc: FC<KolAlertFcProps> = (props, children) => {
 	const {
 		class: classNames = {},
@@ -30,15 +55,7 @@ const KolAlertFc: FC<KolAlertFcProps> = (props, children) => {
 	} = props;
 
 	if (alert) {
-		/**
-		 * - https://developer.mozilla.org/de/docs/Web/API/Navigator/vibrate
-		 * - https://googlechrome.github.io/samples/vibration/
-		 * - Ongoing discussion: https://github.com/public-ui/kolibri/issues/7191
-		 * @todo Move side-effect out of render-function to avoid multiple incarnations.
-		 */
-		if (navigator.userActivation?.hasBeenActive) {
-			navigator?.vibrate?.([100, 75, 100, 75, 100]);
-		}
+		vibrateOnError();
 
 		setTimeout(() => {
 			onAlertTimeout?.();


### PR DESCRIPTION
## Summary
- add `vibrateOnError` helper and call it when alert is active
- avoid vibration unless API available and user gesture detected on mobile
- move documentation comment above `vibrateOnError`

## Testing
- `pnpm lint` *(fails: @typescript-eslint errors)*
- `pnpm test` *(fails: ENOENT jest-test-results.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855f76d9f30832b946177b1b612a71e