### PR TITLE
Update skeleton agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ If we deprecate a feature, we will mark it as deprecated in the code and documen
 - `packages/components` – Stencil based web components
   - `packages/components/src/component` – components
   - `packages/components/src/schema` – schema definitions for all components
+  - `packages/components/src/components/_skeleton` – example component serving as blueprint for new implementations
 - `packages/samples` – sample applications demonstrating usage
   - `packages/samples/angular` – Angular sample app; do not edit
   - `packages/samples/react` – React sample app; all samples; write component samples here

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,6 @@ If we deprecate a feature, we will mark it as deprecated in the code and documen
 - `packages/components` – Stencil based web components
   - `packages/components/src/component` – components
   - `packages/components/src/schema` – schema definitions for all components
-  - `packages/components/src/components/_skeleton` – example component serving as blueprint for new implementations
 - `packages/samples` – sample applications demonstrating usage
   - `packages/samples/angular` – Angular sample app; do not edit
   - `packages/samples/react` – React sample app; all samples; write component samples here

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -94,3 +94,15 @@ When refactoring or adding a component:
 1. Create a `bem.ts` describing the full BEM schema.
 2. Replace class strings with calls to the generated `bem` helper.
 3. Export the schema constant via `src/index.ts` to enable SCSS generation.
+
+## Component and Controller Architecture (Skeleton Blueprint)
+
+The `_skeleton` component demonstrates the recommended pattern for combining a Stencil web component with a stateless functional component and a controller. Key aspects are:
+
+1. Public `@Prop` values mirror to private `@State` variables named `<prop>`.
+2. Each property has a `@Watch` method that normalizes and validates the value using helpers from `internal/functional-components/.../schema/props`. Valid values update state via `controller.setState()`.
+3. `componentWillLoad` calls every watcher once to initialise state.
+4. Business logic lives in a controller extending `BaseController` which only exposes methods to update state or manage refs.
+5. The `render()` method delegates to a stateless functional component, forwarding the current state, `EventEmitter`s and controller callbacks.
+
+Use this blueprint when adding new components.

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -94,15 +94,3 @@ When refactoring or adding a component:
 1. Create a `bem.ts` describing the full BEM schema.
 2. Replace class strings with calls to the generated `bem` helper.
 3. Export the schema constant via `src/index.ts` to enable SCSS generation.
-
-## Component and Controller Architecture (Skeleton Blueprint)
-
-The `_skeleton` component demonstrates the recommended pattern for combining a Stencil web component with a stateless functional component and a controller. Key aspects are:
-
-1. Public `@Prop` values mirror to private `@State` variables named `<prop>`.
-2. Each property has a `@Watch` method that normalizes and validates the value using helpers from `internal/functional-components/.../schema/props`. Valid values update state via `controller.setState()`.
-3. `componentWillLoad` calls every watcher once to initialise state.
-4. Business logic lives in a controller extending `BaseController` which only exposes methods to update state or manage refs.
-5. The `render()` method delegates to a stateless functional component, forwarding the current state, `EventEmitter`s and controller callbacks.
-
-Use this blueprint when adding new components.

--- a/packages/components/src/components/_skeleton/AGENTS.md
+++ b/packages/components/src/components/_skeleton/AGENTS.md
@@ -6,8 +6,8 @@ This folder contains the `_skeleton` showcase component. It demonstrates the rec
 
 - **Web component** – `web-components/skeleton/component.tsx`
   - Public props are prefixed with `_` and mirrored to `@State` variables.
-  - Each prop has a `@Watch` method which normalizes and validates the value using helpers from `internal/schema/props`. Valid values update the state via `SkeletonController.setState`.
-  - `componentWillLoad` calls all watchers once to initialise state before the first render.
+  - Each prop has a `@Watch` method that delegates to `SkeletonController`'s watcher functions for normalization and validation. Valid values update the state via `setState`.
+  - The controller implements `componentWillLoad` where it calls these watchers to initialise state. The web component's lifecycle simply delegates to the controller.
   - Rendering is delegated to `SkeletonFC`. Events (`loaded`) and ref callbacks from the controller are forwarded as props.
 - **Functional component** – `internal/functional-components/skeleton/component.tsx`
   - Receives state, callback handlers and ref setters through its props.
@@ -19,8 +19,7 @@ This folder contains the `_skeleton` showcase component. It demonstrates the rec
 - **Sub component** – `internal/functional-components/click-button` and `web-components/click-button`
   - Shows how to build a small component with its own controller and functional component.
 - **Utility files**
-  - `base-controller.ts` – minimal controller base class providing `setState`.
-  - `generic-types.ts` – generic TypeScript helpers for props, callbacks, emitters and refs.
+  - `base-controller.ts` – minimal controller base class with a protected `setState` method.
 
 ## File layout
 
@@ -36,9 +35,9 @@ This folder contains the `_skeleton` showcase component. It demonstrates the rec
 
 ## Implementation pattern
 
-1. Declare public properties with `@Prop({ reflect: true })` and mirror them to `@State` variables.
-2. Normalize and validate values in a `@Watch` method and update state via `controller.setState()`.
-3. Call each watcher from `componentWillLoad` to set the initial state.
+1. Declare public properties with `@Prop()` and mirror them to `@State` variables.
+2. Implement watcher logic in the controller and delegate from the web component's `@Watch` methods.
+3. The controller's `componentWillLoad()` calls the watchers once for initial state. The web component's lifecycle delegates to this method.
 4. Keep all logic inside the controller; the functional component stays stateless.
 5. Pass events and ref callbacks from the controller to the functional component.
 

--- a/packages/components/src/components/_skeleton/AGENTS.md
+++ b/packages/components/src/components/_skeleton/AGENTS.md
@@ -36,9 +36,9 @@ This folder contains the `_skeleton` showcase component. It demonstrates the rec
 ## Implementation pattern
 
 1. Declare public properties with `@Prop()` and mirror them to `@State` variables.
-2. Implement watcher logic in the controller and delegate from the web component's `@Watch` methods.
-3. The controller's `componentWillLoad()` calls the watchers once for initial state. The web component's lifecycle delegates to this method.
-4. Keep all logic inside the controller; the functional component stays stateless.
+2. Each `@Watch` in the web component only calls a matching controller method. All normalization and validation happen inside the controller.
+3. The controller implements `componentWillLoad()` and invokes its watchers there so parent controllers can trigger the initialization.
+4. All logic lives in the controller which updates state through its protected `setState` method while the functional component stays stateless.
 5. Pass events and ref callbacks from the controller to the functional component.
 
 ### Example usage

--- a/packages/components/src/components/_skeleton/AGENTS.md
+++ b/packages/components/src/components/_skeleton/AGENTS.md
@@ -7,8 +7,8 @@ Functional components themselves hold **no state**. They only render based on th
 ## Architecture summary
 
 - **Web component** – `web-components/skeleton/component.tsx`
-  - Public props are prefixed with `_` and mirrored to `@State` variables.
-  - Each prop has a `@Watch` method that delegates to `SkeletonController`'s watcher functions for normalization and validation. Valid values update the state via `setState`.
+  - Public props are prefixed with `_` and mirrored to private variables.
+  - Each prop has a `@Watch` method observing the `_` prop and delegating to `SkeletonController`'s watcher functions for normalization and validation. Valid values update the private variable via `setState`.
   - The controller implements `componentWillLoad` where it calls these watchers to initialise state. The web component's lifecycle simply delegates to the controller.
   - Rendering is delegated to `SkeletonFC`. Events (`loaded`) and ref callbacks from the controller are forwarded as props.
 - **Functional component** – `internal/functional-components/skeleton/component.tsx`
@@ -38,7 +38,7 @@ Functional components themselves hold **no state**. They only render based on th
 
 ## Implementation pattern
 
-1. Declare public properties with `@Prop()` and mirror them to `@State` variables.
+1. Declare public properties with `@Prop()` and mirror them to private variables.
 2. Each `@Watch` in the web component only calls a matching controller method required by the controller interface. All normalization and validation happen inside the controller.
 3. The controller implements `componentWillLoad()` and invokes its watchers there so parent controllers can trigger the initialization.
 4. All logic lives in the controller which updates state through its protected `setState` method while the functional component stays stateless.

--- a/packages/components/src/components/_skeleton/AGENTS.md
+++ b/packages/components/src/components/_skeleton/AGENTS.md
@@ -12,7 +12,7 @@ Functional components themselves hold **no state**. They only render based on th
   - The controller implements `componentWillLoad` where it calls these watchers to initialise state. The web component's lifecycle simply delegates to the controller.
   - Rendering is delegated to `SkeletonFC`. Events (`loaded`) and ref callbacks from the controller are forwarded as props.
 - **Functional component** – `internal/functional-components/skeleton/component.tsx`
-  - Receives state, callback handlers and ref setters through its props.
+  - Receives the mirrored props via the `SkeletonInternalProps` interface together with callback handlers and ref setters.
   - Contains all DOM markup and composes the `ClickButtonFC` sub component.
 - **Controller** – `internal/functional-components/skeleton/controller.ts`
   - Extends `BaseController` and contains the component logic.
@@ -38,7 +38,7 @@ Functional components themselves hold **no state**. They only render based on th
 
 ## Implementation pattern
 
-1. Declare public properties with `@Prop()` and mirror them to private variables.
+1. Declare public properties with `@Prop()` and mirror them to private variables. List these private values in an `InternalProps` type next to the functional component.
 2. Each `@Watch` in the web component only calls a matching controller method required by the controller interface. All normalization and validation happen inside the controller.
 3. The controller implements `componentWillLoad()` and invokes its watchers there so parent controllers can trigger the initialization.
 4. All logic lives in the controller which updates state through its protected `setState` method while the functional component stays stateless.

--- a/packages/components/src/components/_skeleton/AGENTS.md
+++ b/packages/components/src/components/_skeleton/AGENTS.md
@@ -15,6 +15,7 @@ This folder contains the `_skeleton` showcase component. It demonstrates the rec
 - **Controller** – `internal/functional-components/skeleton/controller.ts`
   - Extends `BaseController` and contains the component logic.
   - Exposes callback handlers (`handleClick`) and ref setters (`setButtonRef`).
+  - Implements watcher methods like `watchLabel` defined by its interface. The web component delegates to these.
   - Only updates state via `setState` and does not manipulate DOM directly.
 - **Sub component** – `internal/functional-components/click-button` and `web-components/click-button`
   - Shows how to build a small component with its own controller and functional component.
@@ -36,7 +37,7 @@ This folder contains the `_skeleton` showcase component. It demonstrates the rec
 ## Implementation pattern
 
 1. Declare public properties with `@Prop()` and mirror them to `@State` variables.
-2. Each `@Watch` in the web component only calls a matching controller method. All normalization and validation happen inside the controller.
+2. Each `@Watch` in the web component only calls a matching controller method required by the controller interface. All normalization and validation happen inside the controller.
 3. The controller implements `componentWillLoad()` and invokes its watchers there so parent controllers can trigger the initialization.
 4. All logic lives in the controller which updates state through its protected `setState` method while the functional component stays stateless.
 5. Pass events and ref callbacks from the controller to the functional component.

--- a/packages/components/src/components/_skeleton/AGENTS.md
+++ b/packages/components/src/components/_skeleton/AGENTS.md
@@ -1,161 +1,49 @@
 # Overview
 
-This folder provides a minimal but fully functional example component. It shows
-how a Stencil web component in KoliBri is organised and can be used as a
-blueprint when implementing new components.
+This folder contains the `_skeleton` showcase component. It demonstrates the recommended interaction between a Stencil web component, a stateless functional component and a controller. Use it as a blueprint when starting new components.
 
-## Todos
+## Architecture summary
 
-- [x] `@Component` - the web component's main class
-- [x] `@Element` - the web component's host element
-- [x] `@Prop` - a property of the web component
-- [x] `@State` - a state variable of the web component and part of the props of the functional component
-- [x] `@Event` - an event emitted by the web component
-- [ ] `@Listen` - a decorator to listen to events
-- [ ] `@Method` - a method exposed by the web component
-- [x] `@Watch` - a watch for changes of properties of the web component
-- [x] `FunctionalComponent` - a stateless functional component that receives props and renders the template
-- [x] `Callbacks` - a set of callback functions to handle actions in the functional component
+- **Web component** – `web-components/skeleton/component.tsx`
+  - Public props are prefixed with `_` and mirrored to `@State` variables.
+  - Each prop has a `@Watch` method which normalizes and validates the value using helpers from `internal/schema/props`. Valid values update the state via `SkeletonController.setState`.
+  - `componentWillLoad` calls all watchers once to initialise state before the first render.
+  - Rendering is delegated to `SkeletonFC`. Events (`loaded`) and ref callbacks from the controller are forwarded as props.
+- **Functional component** – `internal/functional-components/skeleton/component.tsx`
+  - Receives state, callback handlers and ref setters through its props.
+  - Contains all DOM markup and composes the `ClickButtonFC` sub component.
+- **Controller** – `internal/functional-components/skeleton/controller.ts`
+  - Extends `BaseController` and contains the component logic.
+  - Exposes callback handlers (`handleClick`) and ref setters (`setButtonRef`).
+  - Only updates state via `setState` and does not manipulate DOM directly.
+- **Sub component** – `internal/functional-components/click-button` and `web-components/click-button`
+  - Shows how to build a small component with its own controller and functional component.
+- **Utility files**
+  - `base-controller.ts` – minimal controller base class providing `setState`.
+  - `generic-types.ts` – generic TypeScript helpers for props, callbacks, emitters and refs.
 
-## Component architecture
+## File layout
 
-The following guidelines define how we structure component state and properties:
+- `web-components/skeleton/component.tsx` – Stencil component
+- `web-components/click-button/component.tsx` – example button component
+- `internal/functional-components/skeleton/component.tsx` – functional component
+- `internal/functional-components/skeleton/controller.ts` – controller logic
+- `internal/functional-components/click-button/component.tsx` – functional button
+- `internal/functional-components/click-button/controller.ts` – button controller
+- `internal/functional-components/base-controller.ts` – helper base class
+- `internal/functional-components/generic-types.ts` – shared type helpers
+- `internal/schema/props/*.ts` – property types with `normalize*` and `validate*`
 
-- Create a state variable only when a property has a direct and atomic effect on rendering.
-- When several properties form one logical state, combine them into a single state variable, either as a primitive value or an object.
-- Each property may implement `normalizeProperty` and `validateProperty`; call these from the property's `Watch` method.
-- Stateless internal functional components receive props that mirror the web component's state. These props use the same names as the state variables (e.g., `stateA`). They are invoked from the web component's private `render()` method and never inherit from the web component.
-- Complex interactions can be handled inside a component controller. The controller follows the composition pattern and is created by the component.
-- All controllers inherit from a common `BaseController` that exposes a `setState()` helper mirroring Stencil's state mechanism. After normalizing and validating incoming props, a controller updates the web component by calling this method, which triggers a rerender.
-- A minimal implementation looks like this:
+## Implementation pattern
 
-```ts
-export abstract class BaseController<State> {
-	protected constructor(protected readonly component: { [K in keyof State]: State[K] }) {}
-
-	public setState<K extends keyof State>(prop: K, value: State[K]): void {
-		this.component[prop] = value;
-	}
-}
-```
-
-- A web component (e.g. `kol-skeleton`) may compose only one functional components (e.g. `SkeletonFC`). A functional component can compose multiple internal functional components, each with its own controller for handling logic. The controllers and functional components share an interface describing the state they operate on. All rendering happens inside the functional components which receive the state via props.
-- Each functional component receives an immutable instance of its state controller. If the controller exposes several independent values, you may also pass those states individually to the functional component instead of the whole controller.
-- Functional component props combine the component state with callback refs. The controller exposes ref setter functions that connect DOM elements back to the controller.
-
-```ts
-export type SkeletonRefs = {
-       setSpanRef: (el?: HTMLSpanElement) => void;
-};
-
-export type SkeletonEmitter = {
-       onLoadedEmitter: EventEmitter<void>;
-};
-
-export const SkeletonFC: FC<SkeletonState & SkeletonRefs & SkeletonEmitter> = ({
-       nameState,
-       showState,
-       setSpanRef,
-       onLoadedEmitter,
-}) => {
-       if (showState) {
-               setTimeout(() => onLoadedEmitter.emit(), 2000);
-               return <span ref={setSpanRef}>{nameState}</span>;
-       }
-       return null;
-};
-```
-
-```ts
-export type ClickButtonRefs = {
-       setButtonRef: (el?: HTMLButtonElement) => void;
-};
-
-export type ClickButtonCallbacks = {
-       onClick: () => void;
-};
-
-export const ClickButtonFC: FC<ClickButtonRefs & ClickButtonCallbacks> = ({ setButtonRef, onClick }) => (
-       <button
-               ref={setButtonRef}
-               onClick={onClick}
-               onKeyDown={(event): void => {
-                       if (event.key === 'Enter' || event.key === ' ') {
-                               onClick();
-                       }
-               }}
-       >
-               Toggle
-       </button>
-);
-```
-
-The following class diagram shows how a web component exposes public
-properties while maintaining its state in private variables. Every web
-component in KoliBri always attaches a ShadowRoot. The component passes its
-state to a stateless functional component for rendering.
-
-```mermaid
-classDiagram
-    class WebComponent {
-        +stateA
-        +stateB
-        -stateA
-        -stateB
-        -render()
-    }
-    class BaseController {
-        +setState()
-    }
-    class ComponentControllerA {
-    }
-    class ComponentControllerB {
-    }
-    BaseController <|-- ComponentControllerA
-    BaseController <|-- ComponentControllerB
-    class FunctionalComponentA {
-        +stateA
-        +stateB
-        <<stateless>>
-    }
-    class FunctionalComponentB {
-        +stateA
-        +stateB
-        <<stateless>>
-    }
-    WebComponent *-- ComponentControllerA : composes
-    WebComponent *-- ComponentControllerB : composes
-    WebComponent --> FunctionalComponentA : calls in render
-    WebComponent --> FunctionalComponentB : calls in render
-```
-
-### File layout
-
-- `component.tsx` – Stencil web component managing state and watchers.
-- `internal/functional-components` – stateless React-like component and its controller.
-  - `component.tsx` – functional component rendering the template and declaring the shared `SkeletonState` interface.
-  - `controller.ts` – logic for normalizing, validating and updating state via `BaseController`.
-  - `schema/props` – property types with `normalize*` and `validate*` helpers.
-  - `click-button/` – standalone button component handling the click interaction.
-
-### Implementation pattern
-
-1. Declare public properties with `@Prop({ reflect: true })` and mirror them to private state using `@State` variables named `<prop>State`.
-2. Implement a `@Watch` method for each property. Normalize and validate the value inside the watcher and, if valid, call `controller.setState()`.
-3. Call each watcher from `componentWillLoad` to initialise the state before the first render.
-4. The controller only updates state via `setState()` and exposes no watcher methods.
-5. `render()` only delegates to the functional component, passing the current state as props.
-6. Refs are forwarded via callback functions. Define a method like `setSpanRef` on the controller and pass it directly from `render()` so the controller can access DOM elements.
-7. Events are emitted from the functional component. Forward the `EventEmitter` via a prop like `onLoadedEmitter` and call `.emit()` inside the functional component logic.
-8. `SkeletonController` instantiates a `ClickButtonController` for the `ClickButton` subcomponent which toggles the `show` state.
-9. All rendering happens in the functional components which must remain stateless.
-10. Define the component's state interface next to the functional component and implement it in the web component class so Stencil knows which `@State` variables exist.
-
-All watcher methods share a generic `WatchCallback<T>` type defined as `(value?: T) => void`.
-Components can implement a `ComponentWatchers<Props>` interface to type their watcher methods based on the public properties.
+1. Declare public properties with `@Prop({ reflect: true })` and mirror them to `@State` variables.
+2. Normalize and validate values in a `@Watch` method and update state via `controller.setState()`.
+3. Call each watcher from `componentWillLoad` to set the initial state.
+4. Keep all logic inside the controller; the functional component stays stateless.
+5. Pass events and ref callbacks from the controller to the functional component.
 
 ### Example usage
 
 ```html
-<kol-skeleton onSkeletonLoaded="{()" =""> console.log('Skeleton geladen!')}></kol-skeleton>
+<kol-skeleton _label="Foo" _name="Bar" _show></kol-skeleton>
 ```

--- a/packages/components/src/components/_skeleton/AGENTS.md
+++ b/packages/components/src/components/_skeleton/AGENTS.md
@@ -2,6 +2,8 @@
 
 This folder contains the `_skeleton` showcase component. It demonstrates the recommended interaction between a Stencil web component, a stateless functional component and a controller. Use it as a blueprint when starting new components.
 
+Functional components themselves hold **no state**. They only render based on the props they receive. All state must live in a web component which attaches the shadow root. To keep nested components lightweight and still reuse them, we compose multiple functional components within a single web component. That means the web component also manages the state of any internal functional components. Their business logic stays reusable by delegating it to dedicated controllers.
+
 ## Architecture summary
 
 - **Web component** – `web-components/skeleton/component.tsx`

--- a/packages/components/src/components/_skeleton/Agents2.md
+++ b/packages/components/src/components/_skeleton/Agents2.md
@@ -1,0 +1,10 @@
+# Alternatives Konzept
+
+Dieses Dokument beschreibt eine Variante der Architektur, bei der die von außen belegbaren Properties direkt in private `@State`-Variablen gespiegelt werden. Diese Variablen sind ausschließlich innerhalb der Web Component sichtbar und werden nicht Teil des öffentlichen Interfaces.
+
+- Alle `@Prop`-Werte werden in privaten `@State`-Variablen gespeichert. Dadurch lösen Änderungen weiterhin ein Re‑Rendern aus, bleiben aber vor externem Zugriff geschützt.
+- Logikbezogene Zustände können weiterhin über eigene `@State`‑Variablen abgebildet werden.
+- Die Watcher der Web Component rufen lediglich die gleichnamigen Methoden des Controllers auf. Die eigentliche Validierung und Normalisierung findet im Controller statt.
+- Die Methode `componentWillLoad` liegt im Controller und initialisiert dort die Werte, sodass übergeordnete Controller auch Unter‑Controller verwenden können.
+
+Dieses Konzept sorgt für eine klare Trennung zwischen öffentlichen Properties und internem Zustand, ohne auf die Vorteile von Stencils Reaktivität zu verzichten.

--- a/packages/components/src/components/_skeleton/Agents2.md
+++ b/packages/components/src/components/_skeleton/Agents2.md
@@ -1,9 +1,9 @@
 # Alternatives Konzept
 
-Dieses Dokument beschreibt eine Variante der Architektur, bei der die von außen belegbaren Properties direkt in private `@State`-Variablen gespiegelt werden. Diese Variablen sind ausschließlich innerhalb der Web Component sichtbar und werden nicht Teil des öffentlichen Interfaces.
+Dieses Dokument beschreibt eine vereinfachte Variante der Architektur, bei der die von außen belegbaren Properties direkt in private Variablen gespiegelt werden. Diese Variablen sind ausschließlich innerhalb der Web Component sichtbar und werden nicht Teil des öffentlichen Interfaces.
 
-- Alle `@Prop`-Werte werden in privaten `@State`-Variablen gespeichert. Dadurch lösen Änderungen weiterhin ein Re‑Rendern aus, bleiben aber vor externem Zugriff geschützt.
-- Logikbezogene Zustände können weiterhin über eigene `@State`‑Variablen abgebildet werden.
+- Alle `@Prop`-Werte werden in privaten Variablen gespeichert. Änderungen werden über die Reactivität der Props gerendert, bleiben aber vor externem Zugriff geschützt.
+- Logikbezogene Zustände können weiterhin über eigene `@State`‑Variablen oder weitere private Variablen abgebildet werden.
 - Die Watcher der Web Component rufen lediglich die gleichnamigen Methoden des Controllers auf. Die eigentliche Validierung und Normalisierung findet im Controller statt.
 - Die Methode `componentWillLoad` liegt im Controller und initialisiert dort die Werte, sodass übergeordnete Controller auch Unter‑Controller verwenden können.
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
@@ -1,7 +1,7 @@
 export abstract class BaseController<State> {
 	public constructor(protected readonly component: { [K in keyof State]: State[K] }) {}
 
-	public setState<K extends keyof State>(prop: K, value: State[K]): void {
-		this.component[prop] = value;
-	}
+       protected setState<K extends keyof State>(prop: K, value: State[K]): void {
+               this.component[prop] = value;
+       }
 }

--- a/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
@@ -1,7 +1,7 @@
 export abstract class BaseController<State> {
 	public constructor(protected readonly component: { [K in keyof State]: State[K] }) {}
 
-       protected setState<K extends keyof State>(prop: K, value: State[K]): void {
-               this.component[prop] = value;
-       }
+	protected setState<K extends keyof State>(prop: K, value: State[K]): void {
+		this.component[prop] = value;
+	}
 }

--- a/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
@@ -1,7 +1,7 @@
-export abstract class BaseController<State> {
-	public constructor(protected readonly component: { [K in keyof State]: State[K] }) {}
+export abstract class BaseController<Component> {
+	public constructor(protected readonly component: Component) {}
 
-	protected setState<K extends keyof State>(prop: K, value: State[K]): void {
-		this.component[prop] = value;
+	protected setState(prop: string, value: unknown): void {
+		(this.component as Record<string, unknown>)[prop] = value;
 	}
 }

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/component.tsx
@@ -13,9 +13,9 @@ export type ClickButtonRefs = {
 
 export type ClickButtonEmitters = Record<never, never>;
 
-export type ClickButtonState = LabelProp;
+export type ClickButtonInternalProps = LabelProp;
 
-type Props = FunctionalComponentProps<ClickButtonState, ClickButtonCallbacks, ClickButtonEmitters, ClickButtonRefs>;
+type Props = FunctionalComponentProps<ClickButtonInternalProps, ClickButtonCallbacks, ClickButtonEmitters, ClickButtonRefs>;
 
 export const ClickButtonFC: FC<Props> = ({ label, handleClick, refButton }) => (
 	<button

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
@@ -1,15 +1,15 @@
 import { BaseController } from '../base-controller';
 import type { ControllerInterface } from '../generic-types';
-import type { ClickButtonCallbacks, ClickButtonRefs, ClickButtonState } from './component';
+import type { ClickButtonCallbacks, ClickButtonRefs, ClickButtonInternalProps } from './component';
 import { normalizeLabel, validateLabel, type LabelPropType } from '../../schema/props/label';
 
 export class ClickButtonController<State extends object>
 	extends BaseController<State>
-	implements ControllerInterface<ClickButtonState, ClickButtonCallbacks, ClickButtonRefs>
+	implements ControllerInterface<ClickButtonInternalProps, ClickButtonCallbacks, ClickButtonRefs>
 {
 	private buttonRef?: HTMLButtonElement;
 
-	public componentWillLoad(props: Partial<ClickButtonState>): void {
+	public componentWillLoad(props: Partial<ClickButtonInternalProps>): void {
 		this.watchLabel(props.label);
 	}
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
@@ -4,20 +4,23 @@ import type { ClickButtonCallbacks, ClickButtonRefs, ClickButtonState } from './
 import { normalizeLabel, validateLabel, type LabelPropType } from '../schema/props/label';
 
 export class ClickButtonController<State extends ClickButtonState>
-       extends BaseController<State>
-       implements ControllerInterface<ClickButtonState, ClickButtonCallbacks, ClickButtonRefs> {
-       private buttonRef?: HTMLButtonElement;
+	extends BaseController<State>
+	implements ControllerInterface<ClickButtonState, ClickButtonCallbacks, ClickButtonRefs>
+{
+	private buttonRef?: HTMLButtonElement;
 
-       public componentWillLoad(props: Partial<ClickButtonState>): void {
-               this.watchLabel(props.label);
-       }
+	public componentWillLoad(props: Partial<ClickButtonState>): void {
+		this.watchLabel(props.label);
+	}
 
-       public watchLabel = (value?: LabelPropType): void => {
-               const normalized = normalizeLabel(value);
-               if (validateLabel(normalized)) {
-                       this.setState('label', normalized);
-               }
-       };
+	public watchLabel = (value?: LabelPropType): void => {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+		const normalized = normalizeLabel(value);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		if (validateLabel(normalized)) {
+			this.setState('label', normalized as State['label']);
+		}
+	};
 
 	public handleClick = (): void => {
 		// eslint-disable-next-line no-console

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
@@ -1,12 +1,23 @@
 import { BaseController } from '../base-controller';
 import type { ControllerInterface } from '../generic-types';
 import type { ClickButtonCallbacks, ClickButtonRefs, ClickButtonState } from './component';
+import { normalizeLabel, validateLabel, type LabelPropType } from '../schema/props/label';
 
 export class ClickButtonController<State extends ClickButtonState>
-	extends BaseController<State>
-	implements ControllerInterface<ClickButtonCallbacks, ClickButtonRefs>
-{
-	private buttonRef?: HTMLButtonElement;
+       extends BaseController<State>
+       implements ControllerInterface<ClickButtonState, ClickButtonCallbacks, ClickButtonRefs> {
+       private buttonRef?: HTMLButtonElement;
+
+       public componentWillLoad(props: Partial<ClickButtonState>): void {
+               this.watchLabel(props.label);
+       }
+
+       public watchLabel = (value?: LabelPropType): void => {
+               const normalized = normalizeLabel(value);
+               if (validateLabel(normalized)) {
+                       this.setState('label', normalized);
+               }
+       };
 
 	public handleClick = (): void => {
 		// eslint-disable-next-line no-console

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
@@ -1,9 +1,9 @@
 import { BaseController } from '../base-controller';
 import type { ControllerInterface } from '../generic-types';
 import type { ClickButtonCallbacks, ClickButtonRefs, ClickButtonState } from './component';
-import { normalizeLabel, validateLabel, type LabelPropType } from '../schema/props/label';
+import { normalizeLabel, validateLabel, type LabelPropType } from '../../schema/props/label';
 
-export class ClickButtonController<State extends ClickButtonState>
+export class ClickButtonController<State extends object>
 	extends BaseController<State>
 	implements ControllerInterface<ClickButtonState, ClickButtonCallbacks, ClickButtonRefs>
 {
@@ -18,7 +18,7 @@ export class ClickButtonController<State extends ClickButtonState>
 		const normalized = normalizeLabel(value);
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 		if (validateLabel(normalized)) {
-			this.setState('label', normalized as State['label']);
+			this.setState('label', normalized);
 		}
 	};
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
@@ -26,7 +26,7 @@ type ComponentWatchers<Props> = {
 	[K in keyof Props as `watch${Capitalize<string & K>}`]: Callback<Props[K]>;
 };
 
-export type WebComponentInterface<Props, State, Emitters> = ComponentProps<Props> & State & WebComponentEmitters<Emitters> & ComponentWatchers<Props>;
+export type WebComponentInterface<Props, Emitters> = ComponentProps<Props> & WebComponentEmitters<Emitters> & ComponentWatchers<Props>;
 
 export type FunctionalComponentProps<State, Callbacks, Emitters, Refs> = State &
 	ComponentCallbacks<Callbacks> &

--- a/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
@@ -34,17 +34,15 @@ export type FunctionalComponentProps<State, Callbacks, Emitters, Refs> = State &
 	ComponentRefs<Refs>;
 
 type ControllerCallbackHandlers<Callbacks> = {
-       [K in keyof Callbacks as `handle${Capitalize<string & K>}`]: (element?: Callbacks[K]) => void;
+	[K in keyof Callbacks as `handle${Capitalize<string & K>}`]: (element?: Callbacks[K]) => void;
 };
 
 type ControllerRefSetters<Refs> = {
-       [K in keyof Refs as `set${Capitalize<string & K>}Ref`]: (element?: Refs[K]) => void;
+	[K in keyof Refs as `set${Capitalize<string & K>}Ref`]: (element?: Refs[K]) => void;
 };
 
 type ControllerWatchers<Props> = {
-       [K in keyof Props as `watch${Capitalize<string & K>}`]: Callback<Props[K]>;
+	[K in keyof Props as `watch${Capitalize<string & K>}`]: Callback<Props[K]>;
 };
 
-export type ControllerInterface<Props, Callbacks, Refs> = ControllerCallbackHandlers<Callbacks> &
-       ControllerRefSetters<Refs> &
-       ControllerWatchers<Props>;
+export type ControllerInterface<Props, Callbacks, Refs> = ControllerCallbackHandlers<Callbacks> & ControllerRefSetters<Refs> & ControllerWatchers<Props>;

--- a/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
@@ -34,11 +34,17 @@ export type FunctionalComponentProps<State, Callbacks, Emitters, Refs> = State &
 	ComponentRefs<Refs>;
 
 type ControllerCallbackHandlers<Callbacks> = {
-	[K in keyof Callbacks as `handle${Capitalize<string & K>}`]: (element?: Callbacks[K]) => void;
+       [K in keyof Callbacks as `handle${Capitalize<string & K>}`]: (element?: Callbacks[K]) => void;
 };
 
 type ControllerRefSetters<Refs> = {
-	[K in keyof Refs as `set${Capitalize<string & K>}Ref`]: (element?: Refs[K]) => void;
+       [K in keyof Refs as `set${Capitalize<string & K>}Ref`]: (element?: Refs[K]) => void;
 };
 
-export type ControllerInterface<Callbacks, Refs> = ControllerCallbackHandlers<Callbacks> & ControllerRefSetters<Refs>;
+type ControllerWatchers<Props> = {
+       [K in keyof Props as `watch${Capitalize<string & K>}`]: Callback<Props[K]>;
+};
+
+export type ControllerInterface<Props, Callbacks, Refs> = ControllerCallbackHandlers<Callbacks> &
+       ControllerRefSetters<Refs> &
+       ControllerWatchers<Props>;

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/component.tsx
@@ -29,13 +29,13 @@ export type SkeletonRefs = {
 	button: HTMLButtonElement;
 };
 
-export type SkeletonState = {
+export type SkeletonInternalProps = {
 	label: LabelPropType;
 	name: NamePropType;
 	show: ShowPropType;
 };
 
-type Props = FunctionalComponentProps<SkeletonState, SkeletonCallbacks, SkeletonEmitters, SkeletonRefs>;
+type Props = FunctionalComponentProps<SkeletonInternalProps, SkeletonCallbacks, SkeletonEmitters, SkeletonRefs>;
 
 export const SkeletonFC: FC<Props> = ({ label, name, show, onLoaded, handleClick, refButton }) => {
 	setTimeout(() => {

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -7,36 +7,43 @@ import { normalizeName, validateName, type NamePropType } from '../schema/props/
 import { normalizeShow, validateShow, type ShowPropType } from '../schema/props/show';
 
 export class SkeletonController<State extends SkeletonState>
-       extends BaseController<State>
-       implements ControllerInterface<SkeletonState, SkeletonCallbacks, SkeletonRefs> {
-       private readonly clickButtonController = new ClickButtonController<State>(this.component);
+	extends BaseController<State>
+	implements ControllerInterface<SkeletonState, SkeletonCallbacks, SkeletonRefs>
+{
+	private readonly clickButtonController = new ClickButtonController<State>(this.component);
 
-       public componentWillLoad(props: Partial<SkeletonState>): void {
-               this.watchLabel(props.label);
-               this.watchName(props.name);
-               this.watchShow(props.show);
-       }
+	public componentWillLoad(props: Partial<SkeletonState>): void {
+		this.watchLabel(props.label);
+		this.watchName(props.name);
+		this.watchShow(props.show);
+	}
 
-       public watchLabel = (value?: LabelPropType): void => {
-               const normalized = normalizeLabel(value);
-               if (validateLabel(normalized)) {
-                       this.setState('label', normalized);
-               }
-       };
+	public watchLabel = (value?: LabelPropType): void => {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+		const normalized = normalizeLabel(value);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		if (validateLabel(normalized)) {
+			this.setState('label', normalized as State['label']);
+		}
+	};
 
-       public watchName = (value?: NamePropType): void => {
-               const normalized = normalizeName(value);
-               if (validateName(normalized)) {
-                       this.setState('name', normalized);
-               }
-       };
+	public watchName = (value?: NamePropType): void => {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+		const normalized = normalizeName(value);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		if (validateName(normalized)) {
+			this.setState('name', normalized as State['name']);
+		}
+	};
 
-       public watchShow = (value?: ShowPropType): void => {
-               const normalized = normalizeShow(value);
-               if (validateShow(normalized)) {
-                       this.setState('show', normalized);
-               }
-       };
+	public watchShow = (value?: ShowPropType): void => {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+		const normalized = normalizeShow(value);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		if (validateShow(normalized)) {
+			this.setState('show', normalized as State['show']);
+		}
+	};
 
 	public handleClick = (): void => {
 		// eslint-disable-next-line no-console

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -2,11 +2,11 @@ import { BaseController } from '../base-controller';
 import type { ControllerInterface } from '../generic-types';
 import { ClickButtonController } from '../click-button/controller';
 import type { SkeletonCallbacks, SkeletonRefs, SkeletonState } from './component';
-import { normalizeLabel, validateLabel, type LabelPropType } from '../schema/props/label';
-import { normalizeName, validateName, type NamePropType } from '../schema/props/name';
-import { normalizeShow, validateShow, type ShowPropType } from '../schema/props/show';
+import { normalizeLabel, validateLabel, type LabelPropType } from '../../schema/props/label';
+import { normalizeName, validateName, type NamePropType } from '../../schema/props/name';
+import { normalizeShow, validateShow, type ShowPropType } from '../../schema/props/show';
 
-export class SkeletonController<State extends SkeletonState>
+export class SkeletonController<State extends object>
 	extends BaseController<State>
 	implements ControllerInterface<SkeletonState, SkeletonCallbacks, SkeletonRefs>
 {
@@ -23,7 +23,7 @@ export class SkeletonController<State extends SkeletonState>
 		const normalized = normalizeLabel(value);
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 		if (validateLabel(normalized)) {
-			this.setState('label', normalized as State['label']);
+			this.setState('label', normalized);
 		}
 	};
 
@@ -32,7 +32,7 @@ export class SkeletonController<State extends SkeletonState>
 		const normalized = normalizeName(value);
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 		if (validateName(normalized)) {
-			this.setState('name', normalized as State['name']);
+			this.setState('name', normalized);
 		}
 	};
 
@@ -41,7 +41,7 @@ export class SkeletonController<State extends SkeletonState>
 		const normalized = normalizeShow(value);
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 		if (validateShow(normalized)) {
-			this.setState('show', normalized as State['show']);
+			this.setState('show', normalized);
 		}
 	};
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -2,9 +2,41 @@ import { BaseController } from '../base-controller';
 import type { ControllerInterface } from '../generic-types';
 import { ClickButtonController } from '../click-button/controller';
 import type { SkeletonCallbacks, SkeletonRefs, SkeletonState } from './component';
+import { normalizeLabel, validateLabel, type LabelPropType } from '../schema/props/label';
+import { normalizeName, validateName, type NamePropType } from '../schema/props/name';
+import { normalizeShow, validateShow, type ShowPropType } from '../schema/props/show';
 
-export class SkeletonController<State extends SkeletonState> extends BaseController<State> implements ControllerInterface<SkeletonCallbacks, SkeletonRefs> {
-	private readonly clickButtonController = new ClickButtonController<State>(this.component);
+export class SkeletonController<State extends SkeletonState>
+       extends BaseController<State>
+       implements ControllerInterface<SkeletonState, SkeletonCallbacks, SkeletonRefs> {
+       private readonly clickButtonController = new ClickButtonController<State>(this.component);
+
+       public componentWillLoad(props: Partial<SkeletonState>): void {
+               this.watchLabel(props.label);
+               this.watchName(props.name);
+               this.watchShow(props.show);
+       }
+
+       public watchLabel = (value?: LabelPropType): void => {
+               const normalized = normalizeLabel(value);
+               if (validateLabel(normalized)) {
+                       this.setState('label', normalized);
+               }
+       };
+
+       public watchName = (value?: NamePropType): void => {
+               const normalized = normalizeName(value);
+               if (validateName(normalized)) {
+                       this.setState('name', normalized);
+               }
+       };
+
+       public watchShow = (value?: ShowPropType): void => {
+               const normalized = normalizeShow(value);
+               if (validateShow(normalized)) {
+                       this.setState('show', normalized);
+               }
+       };
 
 	public handleClick = (): void => {
 		// eslint-disable-next-line no-console

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -1,18 +1,18 @@
 import { BaseController } from '../base-controller';
 import type { ControllerInterface } from '../generic-types';
 import { ClickButtonController } from '../click-button/controller';
-import type { SkeletonCallbacks, SkeletonRefs, SkeletonState } from './component';
+import type { SkeletonCallbacks, SkeletonRefs, SkeletonInternalProps } from './component';
 import { normalizeLabel, validateLabel, type LabelPropType } from '../../schema/props/label';
 import { normalizeName, validateName, type NamePropType } from '../../schema/props/name';
 import { normalizeShow, validateShow, type ShowPropType } from '../../schema/props/show';
 
 export class SkeletonController<State extends object>
 	extends BaseController<State>
-	implements ControllerInterface<SkeletonState, SkeletonCallbacks, SkeletonRefs>
+	implements ControllerInterface<SkeletonInternalProps, SkeletonCallbacks, SkeletonRefs>
 {
 	private readonly clickButtonController = new ClickButtonController<State>(this.component);
 
-	public componentWillLoad(props: Partial<SkeletonState>): void {
+	public componentWillLoad(props: Partial<SkeletonInternalProps>): void {
 		this.watchLabel(props.label);
 		this.watchName(props.name);
 		this.watchShow(props.show);

--- a/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
@@ -23,14 +23,14 @@ export class KolClickButton implements Interface {
 	@State()
 	public label: LabelPropType = '';
 
-       @Watch('label')
-       public watchLabel(value?: LabelPropType): void {
-               this.controller.watchLabel(value);
-       }
+	@Watch('label')
+	public watchLabel(value?: LabelPropType): void {
+		this.controller.watchLabel(value);
+	}
 
-       public componentWillLoad(): void {
-               this.controller.componentWillLoad({ label: this._label });
-       }
+	public componentWillLoad(): void {
+		this.controller.componentWillLoad({ label: this._label });
+	}
 
 	public render(): JSX.Element {
 		return (

--- a/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from '@stencil/core';
-import { Component, h, Host, Prop, State, Watch } from '@stencil/core';
+import { Component, h, Host, Prop, Watch } from '@stencil/core';
 import type { ClickButtonEmitters } from '../../internal/functional-components/click-button/component';
 import { ClickButtonFC } from '../../internal/functional-components/click-button/component';
 import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
@@ -20,10 +20,9 @@ export class KolClickButton implements Interface {
 	@Prop()
 	public _label!: LabelPropType;
 
-	@State()
 	private label: LabelPropType = '';
 
-	@Watch('label')
+	@Watch('_label')
 	public watchLabel(value?: LabelPropType): void {
 		this.controller.watchLabel(value);
 	}

--- a/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
@@ -4,7 +4,7 @@ import type { ClickButtonEmitters, ClickButtonState } from '../../internal/funct
 import { ClickButtonFC } from '../../internal/functional-components/click-button/component';
 import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
-import { normalizeLabel, validateLabel, type LabelProp, type LabelPropType } from '../../internal/schema/props/label';
+import type { LabelProp, LabelPropType } from '../../internal/schema/props/label';
 
 type Props = LabelProp;
 
@@ -23,23 +23,14 @@ export class KolClickButton implements Interface {
 	@State()
 	public label: LabelPropType = '';
 
-	/**
-	 * Das muss wohl doch in den den Controller.
-	 */
-	@Watch('label')
-	public watchLabel(value?: LabelPropType): void {
-		const normalized = normalizeLabel(value);
-		if (validateLabel(normalized)) {
-			this.controller.setState('label', normalized);
-		}
-	}
+       @Watch('label')
+       public watchLabel(value?: LabelPropType): void {
+               this.controller.watchLabel(value);
+       }
 
-	/**
-	 * Das muss wohl doch in den den Controller.
-	 */
-	public componentWillLoad(): void {
-		this.watchLabel(this._label);
-	}
+       public componentWillLoad(): void {
+               this.controller.componentWillLoad({ label: this._label });
+       }
 
 	public render(): JSX.Element {
 		return (

--- a/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from '@stencil/core';
 import { Component, h, Host, Prop, State, Watch } from '@stencil/core';
-import type { ClickButtonEmitters, ClickButtonState } from '../../internal/functional-components/click-button/component';
+import type { ClickButtonEmitters } from '../../internal/functional-components/click-button/component';
 import { ClickButtonFC } from '../../internal/functional-components/click-button/component';
 import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
@@ -8,7 +8,7 @@ import type { LabelProp, LabelPropType } from '../../internal/schema/props/label
 
 type Props = LabelProp;
 
-type Interface = WebComponentInterface<Props, ClickButtonState, ClickButtonEmitters>;
+type Interface = WebComponentInterface<Props, ClickButtonEmitters>;
 
 @Component({
 	tag: 'kol-click-button',
@@ -21,7 +21,7 @@ export class KolClickButton implements Interface {
 	public _label!: LabelPropType;
 
 	@State()
-	public label: LabelPropType = '';
+	private label: LabelPropType = '';
 
 	@Watch('label')
 	public watchLabel(value?: LabelPropType): void {

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -25,10 +25,10 @@ export class KolSkeleton implements Interface {
 	@State()
 	public label: LabelPropType = '';
 
-        @Watch('label')
-        public watchLabel(value?: LabelPropType): void {
-                this.controller.watchLabel(value);
-        }
+	@Watch('label')
+	public watchLabel(value?: LabelPropType): void {
+		this.controller.watchLabel(value);
+	}
 
 	@Prop()
 	public _name!: NamePropType;
@@ -36,10 +36,10 @@ export class KolSkeleton implements Interface {
 	@State()
 	public name: NamePropType = '';
 
-        @Watch('name')
-        public watchName(value?: NamePropType): void {
-                this.controller.watchName(value);
-        }
+	@Watch('name')
+	public watchName(value?: NamePropType): void {
+		this.controller.watchName(value);
+	}
 
 	@Prop()
 	public _show?: ShowPropType;
@@ -47,20 +47,20 @@ export class KolSkeleton implements Interface {
 	@State()
 	public show: ShowPropType = false;
 
-        @Watch('show')
-        public watchShow(value?: ShowPropType): void {
-                this.controller.watchShow(value);
-        }
+	@Watch('show')
+	public watchShow(value?: ShowPropType): void {
+		this.controller.watchShow(value);
+	}
 
 	@Event() public loaded!: EventEmitter<number>;
 
-        public componentWillLoad(): void {
-                this.controller.componentWillLoad({
-                        label: this._label,
-                        name: this._name,
-                        show: this._show,
-                });
-        }
+	public componentWillLoad(): void {
+		this.controller.componentWillLoad({
+			label: this._label,
+			name: this._name,
+			show: this._show,
+		});
+	}
 
 	public render(): JSX.Element {
 		return (

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -1,7 +1,7 @@
 import type { EventEmitter, JSX } from '@stencil/core';
 import { Component, Event, h, Host, Prop, State, Watch } from '@stencil/core';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
-import type { SkeletonEmitters, SkeletonState } from '../../internal/functional-components/skeleton/component';
+import type { SkeletonEmitters } from '../../internal/functional-components/skeleton/component';
 import { SkeletonFC } from '../../internal/functional-components/skeleton/component';
 import { SkeletonController } from '../../internal/functional-components/skeleton/controller';
 import type { LabelProp, LabelPropType } from '../../internal/schema/props/label';
@@ -10,7 +10,7 @@ import type { ShowProp, ShowPropType } from '../../internal/schema/props/show';
 
 type Props = LabelProp & NameProp & ShowProp;
 
-type Interface = WebComponentInterface<Props, SkeletonState, SkeletonEmitters>;
+type Interface = WebComponentInterface<Props, SkeletonEmitters>;
 
 @Component({
 	tag: 'kol-skeleton',
@@ -23,7 +23,7 @@ export class KolSkeleton implements Interface {
 	public _label!: LabelPropType;
 
 	@State()
-	public label: LabelPropType = '';
+	private label: LabelPropType = '';
 
 	@Watch('label')
 	public watchLabel(value?: LabelPropType): void {
@@ -34,7 +34,7 @@ export class KolSkeleton implements Interface {
 	public _name!: NamePropType;
 
 	@State()
-	public name: NamePropType = '';
+	private name: NamePropType = '';
 
 	@Watch('name')
 	public watchName(value?: NamePropType): void {
@@ -45,7 +45,7 @@ export class KolSkeleton implements Interface {
 	public _show?: ShowPropType;
 
 	@State()
-	public show: ShowPropType = false;
+	private show: ShowPropType = false;
 
 	@Watch('show')
 	public watchShow(value?: ShowPropType): void {

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -1,5 +1,5 @@
 import type { EventEmitter, JSX } from '@stencil/core';
-import { Component, Event, h, Host, Prop, State, Watch } from '@stencil/core';
+import { Component, Event, h, Host, Prop, Watch } from '@stencil/core';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
 import type { SkeletonEmitters } from '../../internal/functional-components/skeleton/component';
 import { SkeletonFC } from '../../internal/functional-components/skeleton/component';
@@ -22,10 +22,9 @@ export class KolSkeleton implements Interface {
 	@Prop()
 	public _label!: LabelPropType;
 
-	@State()
 	private label: LabelPropType = '';
 
-	@Watch('label')
+	@Watch('_label')
 	public watchLabel(value?: LabelPropType): void {
 		this.controller.watchLabel(value);
 	}
@@ -33,10 +32,9 @@ export class KolSkeleton implements Interface {
 	@Prop()
 	public _name!: NamePropType;
 
-	@State()
 	private name: NamePropType = '';
 
-	@Watch('name')
+	@Watch('_name')
 	public watchName(value?: NamePropType): void {
 		this.controller.watchName(value);
 	}
@@ -44,10 +42,9 @@ export class KolSkeleton implements Interface {
 	@Prop()
 	public _show?: ShowPropType;
 
-	@State()
 	private show: ShowPropType = false;
 
-	@Watch('show')
+	@Watch('_show')
 	public watchShow(value?: ShowPropType): void {
 		this.controller.watchShow(value);
 	}

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -6,9 +6,7 @@ import { SkeletonFC } from '../../internal/functional-components/skeleton/compon
 import { SkeletonController } from '../../internal/functional-components/skeleton/controller';
 import type { LabelProp, LabelPropType } from '../../internal/schema/props/label';
 import type { NameProp, NamePropType } from '../../internal/schema/props/name';
-import { normalizeName, validateName } from '../../internal/schema/props/name';
 import type { ShowProp, ShowPropType } from '../../internal/schema/props/show';
-import { normalizeShow, validateShow } from '../../internal/schema/props/show';
 
 type Props = LabelProp & NameProp & ShowProp;
 
@@ -27,13 +25,10 @@ export class KolSkeleton implements Interface {
 	@State()
 	public label: LabelPropType = '';
 
-	@Watch('label')
-	public watchLabel(value?: NamePropType): void {
-		const normalized = normalizeName(value);
-		if (validateName(normalized)) {
-			this.controller.setState('label', normalized);
-		}
-	}
+        @Watch('label')
+        public watchLabel(value?: LabelPropType): void {
+                this.controller.watchLabel(value);
+        }
 
 	@Prop()
 	public _name!: NamePropType;
@@ -41,13 +36,10 @@ export class KolSkeleton implements Interface {
 	@State()
 	public name: NamePropType = '';
 
-	@Watch('name')
-	public watchName(value?: NamePropType): void {
-		const normalized = normalizeName(value);
-		if (validateName(normalized)) {
-			this.controller.setState('name', normalized);
-		}
-	}
+        @Watch('name')
+        public watchName(value?: NamePropType): void {
+                this.controller.watchName(value);
+        }
 
 	@Prop()
 	public _show?: ShowPropType;
@@ -55,21 +47,20 @@ export class KolSkeleton implements Interface {
 	@State()
 	public show: ShowPropType = false;
 
-	@Watch('show')
-	public watchShow(value?: ShowPropType): void {
-		const normalized = normalizeShow(value);
-		if (validateShow(normalized)) {
-			this.controller.setState('show', normalized);
-		}
-	}
+        @Watch('show')
+        public watchShow(value?: ShowPropType): void {
+                this.controller.watchShow(value);
+        }
 
 	@Event() public loaded!: EventEmitter<number>;
 
-	public componentWillLoad(): void {
-		this.watchLabel(this._label);
-		this.watchName(this._name);
-		this.watchShow(this._show);
-	}
+        public componentWillLoad(): void {
+                this.controller.componentWillLoad({
+                        label: this._label,
+                        name: this._name,
+                        show: this._show,
+                });
+        }
 
 	public render(): JSX.Element {
 		return (


### PR DESCRIPTION
## Summary
- remove `_skeleton` bullet from root instructions
- restore component guidelines in `packages/components/AGENTS.md`
- rewrite `_skeleton/AGENTS.md` with concise overview of the web component, functional component and controller interaction

## Testing
- `pnpm format`

------
https://chatgpt.com/codex/tasks/task_e_688ad9731098832bb85127275b5653e2