### PR TITLE
feat(components): add focus and keydown to skeleton

### DIFF
--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
@@ -27,6 +27,10 @@ export class ClickButtonController<Host extends WebComponentInterface<ClickButto
 		console.log(this, this.buttonRef, 'button clicked');
 	};
 
+	public focusButton = (): void => {
+		this.buttonRef?.focus();
+	};
+
 	public setButtonRef = (element?: HTMLButtonElement): void => {
 		this.buttonRef = element;
 	};

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -44,6 +44,10 @@ export class SkeletonController<Host extends WebComponentInterface<SkeletonRende
 		console.log(this, 'button clicked');
 	};
 
+	public focusButton = (): void => {
+		this.clickButtonController.focusButton();
+	};
+
 	public setButtonRef = (element?: HTMLButtonElement): void => {
 		this.clickButtonController.setButtonRef(element);
 	};

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -1,5 +1,5 @@
 import type { EventEmitter, JSX } from '@stencil/core';
-import { Component, Event, h, Host, Prop, Watch } from '@stencil/core';
+import { Component, Event, Listen, Method, h, Host, Prop, Watch } from '@stencil/core';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
 import type { SkeletonEmitters, SkeletonRenderProps } from '../../internal/functional-components/skeleton/component';
 import { SkeletonFC } from '../../internal/functional-components/skeleton/component';
@@ -37,6 +37,19 @@ export class KolSkeleton implements WebComponentInterface<SkeletonRenderProps, P
 	@Watch('show')
 	public watchShow(value?: ShowPropType): void {
 		this.controller.watchShow(value);
+	}
+
+	@Method()
+	public focusButton(): Promise<void> {
+		this.controller.focusButton();
+		return Promise.resolve();
+	}
+
+	@Listen('keydown')
+	public handleKeyDown(event: KeyboardEvent): void {
+		if (event.key === 'Enter' || event.key === ' ') {
+			this.controller.handleClick();
+		}
 	}
 
 	@Event() public loaded!: EventEmitter<number>;

--- a/packages/components/src/components/_skeleton/web-components/skeleton/readme.md
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/readme.md
@@ -1,5 +1,12 @@
 # kol-skeleton
 
+Diese Beispiel-Komponente demonstriert die Verwendung von `@Method` und `@Listen`.
+
+## APIs
+
+- `focusButton()` fokussiert den Button über den Controller.
+- Ein `keydown`-Handler reagiert auf `Enter` und `Space` und ruft `handleClick` auf.
+
 <!-- Auto Generated Below -->
 
 ## Properties
@@ -14,5 +21,13 @@
 | Event    | Description | Type                  |
 | -------- | ----------- | --------------------- |
 | `loaded` |             | `CustomEvent<number>` |
+
+## Methods
+
+### `focusButton() => Promise<void>`
+
+#### Returns
+
+Type: `Promise<void>`
 
 ---


### PR DESCRIPTION
## Summary
- expose `focusButton` method on skeleton example
- demonstrate `@Listen` with a keydown handler
- document skeleton APIs

## Testing
- `pnpm --filter @public-ui/components lint` (passed)
- `pnpm test`
- `pnpm build` (failed: missing entry module)
- `pnpm lint` (failed: missing module in react sample)


------
https://chatgpt.com/codex/tasks/task_e_688dadb6933c832bbdb48e678cba398d