### PR TITLE
docs: enhance skeleton arc42 blueprint

### DIFF
--- a/packages/components/src/components/_skeleton/ARC42.md
+++ b/packages/components/src/components/_skeleton/ARC42.md
@@ -89,7 +89,7 @@ classDiagram
 
 ## 6. Runtime View
 
-The following sequence demonstrates how an external update propagates through the layers.
+The following sequence demonstrates how an external update is normalised and validated before it propagates through the layers.
 
 ```mermaid
 sequenceDiagram
@@ -102,6 +102,8 @@ sequenceDiagram
     WC->>CTRL: watchCount(5)
     CTRL->>S: normalizeCount(5)
     S-->>CTRL: 5
+    CTRL->>S: validateCount(5)
+    S-->>CTRL: ok
     CTRL->>WC: update count
     WC->>FC: render(count)
     FC-->>U: updated markup

--- a/packages/components/src/components/_skeleton/ARC42.md
+++ b/packages/components/src/components/_skeleton/ARC42.md
@@ -4,6 +4,13 @@
 
 The `kol` skeleton component blueprint demonstrates how KoliBri web components can be built in a highly maintainable and decoupled fashion. It is designed as a minimal, yet complete, reference implementation for new components.
 
+Representative code artifacts for each layer:
+
+- [Web component](./web-components/skeleton/component.tsx) – public API and watchers
+- [Controller](./internal/functional-components/skeleton/controller.ts) – business logic
+- [Renderer](./internal/functional-components/skeleton/component.tsx) – stateless view
+- [Schema helpers](./internal/schema/props) – prop types and validation
+
 Primary goals:
 
 - illustrate separation of concerns for long-term maintainability
@@ -41,6 +48,19 @@ The blueprint enforces unidirectional data flow and delegates responsibilities t
 - Schema helpers define canonical prop types and validation rules close to the data model.
 
 This strategy yields strong decoupling so that each layer can evolve independently.
+
+### Watcher Example
+
+Incoming props are normalised in dedicated watchers before reaching the controller:
+
+```ts
+@Watch('_count')
+public watchCount(value?: CountPropType): void {
+  this.controller.watchCount(value);
+}
+```
+
+See the [controller](./internal/functional-components/skeleton/controller.ts) for the corresponding validation logic.
 
 ## 5. Building Block View
 
@@ -99,15 +119,24 @@ The skeleton ships as part of the `@public-ui/components` package. During build 
 
 ## 9. Design Decisions
 
-1. Use underscored public props to clearly separate external inputs from internal state.
-2. Delegate all normalization and validation to the controller to keep renderers pure.
-3. Use functional components for rendering to avoid side effects.
+1. **Underscored public props**
+   - _Alternative_: mirror external props directly without underscores.
+   - _Reason_: underscores make the separation between public API and internal state explicit.
+2. **Centralised validation in the controller**
+   - _Alternative_: perform validation inside prop watchers.
+   - _Reason_: keeping validation in the controller makes testing and reuse easier.
+3. **Functional component rendering**
+   - _Alternative_: render JSX directly inside the web component class.
+   - _Reason_: a pure renderer improves testability and eliminates side effects.
 
 ## 10. Quality Requirements
 
 - Maintainability: isolated layers and type-safety reduce the cost of change.
 - Reliability: schema helpers validate every external value before it mutates state.
 - Testability: controllers and functional components can be unit tested in isolation.
+- Performance: stateless rendering and minimal watchers reduce unnecessary work.
+- Accessibility: follow repository-wide a11y presets and avoid title attributes in favour of `KolTooltip`.
+- Security: avoid direct DOM injection; rely on typed props and controller validation to prevent XSS.
 
 ## 11. Risks and Technical Debt
 
@@ -120,3 +149,5 @@ The skeleton ships as part of the `@public-ui/components` package. During build 
 - **Functional Component** – pure renderer without side effects.
 - **Schema Helper** – utility providing normalization and validation functions.
 - **Watch Decorator** – Stencil decorator that observes prop changes.
+- **Stencil** – compiler for building framework-agnostic web components.
+- **BEM** – Block Element Modifier naming convention for CSS class names.

--- a/packages/components/src/components/_skeleton/ARC42.md
+++ b/packages/components/src/components/_skeleton/ARC42.md
@@ -47,6 +47,17 @@ The blueprint enforces unidirectional data flow and delegates responsibilities t
 - Functional components render pure JSX based on provided props.
 - Schema helpers define canonical prop types and validation rules close to the data model.
 
+### RenderProps Pattern
+
+A critical design principle is that **functional components always render using RenderProps**, which are either:
+
+1. **Normalized and validated external props** - incoming props that have been processed through schema helpers
+2. **Internal component state** - derived or computed values managed by the controller
+
+This ensures that the renderer never works with raw, unvalidated data. All values passed to the functional component have been through the controller's validation pipeline, maintaining type safety and data integrity throughout the rendering process.
+
+**RenderProps must always be initialized** before being passed to the functional component. This prevents rendering with undefined or uninitialized values and ensures that the component can safely render at any point in its lifecycle without encountering unexpected undefined states.
+
 This strategy yields strong decoupling so that each layer can evolve independently.
 
 ### Watcher Example
@@ -103,9 +114,10 @@ sequenceDiagram
     CTRL->>S: normalizeCount(5)
     S-->>CTRL: 5
     CTRL->>S: validateCount(5)
-    S-->>CTRL: ok
+    S-->>CTRL: true
     CTRL->>WC: update count
-    WC->>FC: render(count)
+    WC->>FC: render(renderProps)
+    Note over FC: renderProps contain normalized/validated data or internal state
     FC-->>U: updated markup
 ```
 
@@ -118,6 +130,7 @@ The skeleton ships as part of the `@public-ui/components` package. During build 
 - **Decoupling**: Each layer only knows its direct neighbours. Controllers can be reused or replaced without altering renderers or schemas.
 - **Event-driven communication**: User interaction is emitted as DOM events rather than calling functions across layers.
 - **Type safety**: Generics enforce compile-time contracts between components and controllers.
+- **RenderProps Pattern**: Functional components exclusively receive RenderProps that contain either normalized/validated external data or internal component state. RenderProps must always be initialized to prevent rendering with undefined values. This guarantees that rendering logic never operates on raw, unvalidated inputs and maintains data integrity throughout the component lifecycle.
 
 ## 9. Design Decisions
 
@@ -148,7 +161,8 @@ The skeleton ships as part of the `@public-ui/components` package. During build 
 ## 12. Glossary
 
 - **Controller** – orchestrates state transitions and validation.
-- **Functional Component** – pure renderer without side effects.
+- **Functional Component** – pure renderer without side effects that exclusively works with RenderProps.
+- **RenderProps** – normalized and validated props or internal state passed to functional components for rendering. Must always be initialized before use.
 - **Schema Helper** – utility providing normalization and validation functions.
 - **Watch Decorator** – Stencil decorator that observes prop changes.
 - **Stencil** – compiler for building framework-agnostic web components.

--- a/packages/components/src/components/_skeleton/ARC42.md
+++ b/packages/components/src/components/_skeleton/ARC42.md
@@ -80,22 +80,24 @@ classDiagram
     class WebComponent {
         +_count : number
         +watchCount()
+        +render()
     }
     class Controller {
         +watchCount(value)
         +handleClick()
+        +getRenderProps()
     }
     class FunctionalComponent {
-        +render()
+        <<stateless>>
+        +render(props)
     }
     class SchemaHelpers {
         +normalizeCount()
         +validateCount()
     }
-    WebComponent --> Controller
-    Controller --> FunctionalComponent
-    WebComponent ..> SchemaHelpers
-    Controller ..> SchemaHelpers
+    WebComponent *-- Controller : uses
+    WebComponent *-- FunctionalComponent : uses
+    Controller ..> SchemaHelpers : uses
 ```
 
 ## 6. Runtime View
@@ -128,6 +130,7 @@ The skeleton ships as part of the `@public-ui/components` package. During build 
 ## 8. Cross-cutting Concepts
 
 - **Decoupling**: Each layer only knows its direct neighbours. Controllers can be reused or replaced without altering renderers or schemas.
+- **Template Method Pattern**: The WebComponent defines the overall component lifecycle and structure (template), while the Controller implements the specific business logic steps. The WebComponent provides itself as a reference to the Controller, allowing the Controller to modify the component's state during the execution of the template.
 - **Event-driven communication**: User interaction is emitted as DOM events rather than calling functions across layers.
 - **Type safety**: Generics enforce compile-time contracts between components and controllers.
 - **RenderProps Pattern**: Functional components exclusively receive RenderProps that contain either normalized/validated external data or internal component state. RenderProps must always be initialized to prevent rendering with undefined values. This guarantees that rendering logic never operates on raw, unvalidated inputs and maintains data integrity throughout the component lifecycle.


### PR DESCRIPTION
## Summary
- reference code locations for each layer of the skeleton blueprint
- document watcher example and rationale for key design decisions
- expand quality and glossary sections

## Testing
- `pnpm exec prettier --write packages/components/src/components/_skeleton/ARC42.md`


------
https://chatgpt.com/codex/tasks/task_e_688f5a6758c8832b8b2aa3296d183785