### PR TITLE
refactor: move skeleton render props to controller

### DIFF
--- a/packages/components/src/components/_skeleton/AGENTS.md
+++ b/packages/components/src/components/_skeleton/AGENTS.md
@@ -7,7 +7,7 @@ This skeleton demonstrates **Separation of Concerns** through layered architectu
 ## Layer Responsibilities
 
 - **Web component** – public API surface. Incoming `@Prop` values are exposed with a leading `_` (e.g. `_count`). `@Watch` decorators must observe the underscored props (for example `@Watch('_count')`) to normalise and validate external values before delegating to the controller. Render props are accessed via `controller.getRenderProps()` instead of mirroring them locally.
-- **Controller** – encapsulates business logic and state transitions. It coordinates prop watchers, updates render props via `setRenderProps` and can compose other controllers for additional behaviour.
+- **Controller** – encapsulates business logic and state transitions. It coordinates prop watchers, updates render props directly and can compose other controllers for additional behaviour.
 - **Functional component** – pure, stateless renderer that receives the current state snapshot together with callbacks, emitters and refs. It never mutates data and communicates through events.
 - **Schema utilities** – prop type declarations plus `normalize*/validate*` helpers that keep domain rules close to the data model.
 

--- a/packages/components/src/components/_skeleton/AGENTS.md
+++ b/packages/components/src/components/_skeleton/AGENTS.md
@@ -6,8 +6,8 @@ This skeleton demonstrates **Separation of Concerns** through layered architectu
 
 ## Layer Responsibilities
 
-- **Web component** – public API surface. Incoming `@Prop` values are exposed with a leading `_` (e.g. `_count`) and mirrored to internal state fields without the underscore. `@Watch` decorators must observe the underscored props (for example `@Watch('_count')`) to normalise and validate external values before delegating to the controller.
-- **Controller** – encapsulates business logic and state transitions. It coordinates prop watchers, updates render props via `setRenderPropsOrStates` and can compose other controllers for additional behaviour.
+- **Web component** – public API surface. Incoming `@Prop` values are exposed with a leading `_` (e.g. `_count`). `@Watch` decorators must observe the underscored props (for example `@Watch('_count')`) to normalise and validate external values before delegating to the controller. Render props are accessed via `controller.getRenderProps()` instead of mirroring them locally.
+- **Controller** – encapsulates business logic and state transitions. It coordinates prop watchers, updates render props via `setRenderProps` and can compose other controllers for additional behaviour.
 - **Functional component** – pure, stateless renderer that receives the current state snapshot together with callbacks, emitters and refs. It never mutates data and communicates through events.
 - **Schema utilities** – prop type declarations plus `normalize*/validate*` helpers that keep domain rules close to the data model.
 
@@ -65,10 +65,10 @@ Web components must initialize controllers by passing current render props to en
 ```typescript
 public componentWillLoad(): void {
   this.controller.componentWillLoad({
-    count: this.count,
-    label: this.label,
-    name: this.name,
-    show: this.show,
+    count: this._count,
+    label: 'Label',
+    name: this._name,
+    show: this._show,
   });
 }
 ```

--- a/packages/components/src/components/_skeleton/ARC42.md
+++ b/packages/components/src/components/_skeleton/ARC42.md
@@ -46,16 +46,16 @@ The blueprint enforces unidirectional data flow and delegates responsibilities t
 - Functional components render pure JSX based on provided props.
 - Schema helpers define canonical prop types and validation rules close to the data model.
 
-### RenderProps Pattern
+### Props Pattern
 
-A critical design principle is that **functional components always render using RenderProps**, which are either:
+A critical design principle is that **functional components always render using Props**, which are either:
 
 1. **Normalized and validated external props** - incoming props that have been processed through schema helpers
 2. **Internal component state** - derived or computed values managed by the controller
 
 This ensures that the renderer never works with raw, unvalidated data. All values passed to the functional component have been through the controller's validation pipeline, maintaining type safety and data integrity throughout the rendering process.
 
-**RenderProps must always be initialized** before being passed to the functional component. This prevents rendering with undefined or uninitialized values and ensures that the component can safely render at any point in its lifecycle without encountering unexpected undefined states.
+**Props must always be initialized** before being passed to the functional component. This prevents rendering with undefined or uninitialized values and ensures that the component can safely render at any point in its lifecycle without encountering unexpected undefined states.
 
 This strategy yields strong decoupling so that each layer can evolve independently.
 
@@ -132,7 +132,7 @@ The skeleton ships as part of the `@public-ui/components` package. During build 
 - **Template Method Pattern**: The WebComponent defines the overall component lifecycle and structure (template), while the Controller implements the specific business logic steps. The WebComponent provides itself as a reference to the Controller, allowing the Controller to modify the component's state during the execution of the template.
 - **Event-driven communication**: User interaction is emitted as DOM events rather than calling functions across layers.
 - **Type safety**: Generics enforce compile-time contracts between components and controllers.
-- **RenderProps Pattern**: Functional components exclusively receive RenderProps that contain either normalized/validated external data or internal component state. RenderProps must always be initialized to prevent rendering with undefined values. This guarantees that rendering logic never operates on raw, unvalidated inputs and maintains data integrity throughout the component lifecycle.
+- **Props Pattern**: Functional components exclusively receive Props that contain either normalized/validated external data or internal component state. Props must always be initialized to prevent rendering with undefined values. This guarantees that rendering logic never operates on raw, unvalidated inputs and maintains data integrity throughout the component lifecycle.
 
 ## 9. Design Decisions
 
@@ -163,8 +163,8 @@ The skeleton ships as part of the `@public-ui/components` package. During build 
 ## 12. Glossary
 
 - **Controller** – orchestrates state transitions and validation.
-- **Functional Component** – pure renderer without side effects that exclusively works with RenderProps.
-- **RenderProps** – normalized and validated props or internal state passed to functional components for rendering. Must always be initialized before use.
+- **Functional Component** – pure renderer without side effects that exclusively works with Props.
+- **Props** – normalized and validated props or internal state passed to functional components for rendering. Must always be initialized before use.
 - **Schema Helper** – utility providing normalization and validation functions.
 - **Watch Decorator** – Stencil decorator that observes prop changes.
 - **Stencil** – compiler for building framework-agnostic web components.

--- a/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
@@ -1,15 +1,12 @@
 import type { RequiredRenderProps } from './generic-types';
 
 export abstract class BaseController<Host, RenderProps> {
-	protected renderProps = {} as RequiredRenderProps<RenderProps>;
+	public constructor(
+		protected readonly component: Host,
+		protected renderProps: RequiredRenderProps<RenderProps>,
+	) {}
 
-	public constructor(protected readonly component: Host) {}
-
-	protected setRenderProps<K extends keyof RenderProps>(prop: K, value: NonNullable<RenderProps[K]>): void {
-		this.renderProps[prop] = value;
-	}
-
-	protected setStates<K extends keyof Host>(prop: K, value: Host[K]): void {
+	protected setState<K extends keyof Host>(prop: K, value: Host[K]): void {
 		this.component[prop] = value;
 	}
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
@@ -1,14 +1,10 @@
 import type { RequiredRenderProps } from './generic-types';
 
 export abstract class BaseController<Host, RenderProps> {
-	private renderProps: RequiredRenderProps<RenderProps>;
-
 	public constructor(
 		protected readonly component: Host,
-		renderProps: RequiredRenderProps<RenderProps>,
-	) {
-		this.renderProps = renderProps;
-	}
+		private readonly renderProps: RequiredRenderProps<RenderProps>,
+	) {}
 
 	protected setState<K extends keyof Host>(prop: K, value: Host[K]): void {
 		this.component[prop] = value;

--- a/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
@@ -1,13 +1,13 @@
 import type { RequiredRenderProps } from './generic-types';
 
-export abstract class BaseController<RenderProps> {
-	public constructor(private readonly props: RequiredRenderProps<RenderProps>) {}
+export abstract class BaseController<Props> {
+	public constructor(private readonly props: RequiredRenderProps<Props>) {}
 
-	protected setProp<K extends keyof RenderProps>(key: K, value: RequiredRenderProps<RenderProps>[K]): void {
+	protected setProp<K extends keyof Props>(key: K, value: RequiredRenderProps<Props>[K]): void {
 		this.props[key] = value;
 	}
 
-	public getProps(): RequiredRenderProps<RenderProps> {
+	public getProps(): RequiredRenderProps<Props> {
 		return this.props;
 	}
 }

--- a/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
@@ -1,7 +1,19 @@
-export abstract class BaseController<Host> {
+import type { RequiredRenderProps } from './generic-types';
+
+export abstract class BaseController<Host, RenderProps> {
+	protected renderProps = {} as RequiredRenderProps<RenderProps>;
+
 	public constructor(protected readonly component: Host) {}
 
-	public setRenderPropsOrStates<K extends keyof Host>(prop: K, value: Host[K]): void {
+	protected setRenderProps<K extends keyof RenderProps>(prop: K, value: NonNullable<RenderProps[K]>): void {
+		this.renderProps[prop] = value;
+	}
+
+	protected setStates<K extends keyof Host>(prop: K, value: Host[K]): void {
 		this.component[prop] = value;
+	}
+
+	public getRenderProps(): RequiredRenderProps<RenderProps> {
+		return this.renderProps;
 	}
 }

--- a/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
@@ -1,13 +1,21 @@
 import type { RequiredRenderProps } from './generic-types';
 
 export abstract class BaseController<Host, RenderProps> {
+	private renderProps: RequiredRenderProps<RenderProps>;
+
 	public constructor(
 		protected readonly component: Host,
-		protected renderProps: RequiredRenderProps<RenderProps>,
-	) {}
+		renderProps: RequiredRenderProps<RenderProps>,
+	) {
+		this.renderProps = renderProps;
+	}
 
 	protected setState<K extends keyof Host>(prop: K, value: Host[K]): void {
 		this.component[prop] = value;
+	}
+
+	protected setRenderProp<K extends keyof RenderProps>(prop: K, value: RequiredRenderProps<RenderProps>[K]): void {
+		this.renderProps[prop] = value;
 	}
 
 	public getRenderProps(): RequiredRenderProps<RenderProps> {

--- a/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/base-controller.ts
@@ -1,20 +1,13 @@
 import type { RequiredRenderProps } from './generic-types';
 
-export abstract class BaseController<Host, RenderProps> {
-	public constructor(
-		protected readonly component: Host,
-		private readonly renderProps: RequiredRenderProps<RenderProps>,
-	) {}
+export abstract class BaseController<RenderProps> {
+	public constructor(private readonly props: RequiredRenderProps<RenderProps>) {}
 
-	protected setState<K extends keyof Host>(prop: K, value: Host[K]): void {
-		this.component[prop] = value;
+	protected setProp<K extends keyof RenderProps>(key: K, value: RequiredRenderProps<RenderProps>[K]): void {
+		this.props[key] = value;
 	}
 
-	protected setRenderProp<K extends keyof RenderProps>(prop: K, value: RequiredRenderProps<RenderProps>[K]): void {
-		this.renderProps[prop] = value;
-	}
-
-	public getRenderProps(): RequiredRenderProps<RenderProps> {
-		return this.renderProps;
+	public getProps(): RequiredRenderProps<RenderProps> {
+		return this.props;
 	}
 }

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
@@ -10,8 +10,8 @@ export class ClickButtonController<Host extends WebComponentInterface>
 {
 	private buttonRef?: HTMLButtonElement;
 
-	public constructor(component: Host) {
-		super(component, { label: '' });
+	public constructor(component: Host, renderProps: Partial<ClickButtonRenderProps> = {}) {
+		super(component, { label: '', ...renderProps });
 	}
 
 	public componentWillLoad(props: ClickButtonRenderProps): void {

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
@@ -1,17 +1,19 @@
 import type { LabelPropType } from '../../schema/props/label';
 import { normalizeLabel, validateLabel } from '../../schema/props/label';
 import { BaseController } from '../base-controller';
-import type { ControllerInterface, WebComponentInterface } from '../generic-types';
+import type { ControllerInterface } from '../generic-types';
 import type { ClickButtonCallbacks, ClickButtonRefs, ClickButtonRenderProps } from './component';
 
-export class ClickButtonController<Host extends WebComponentInterface>
-	extends BaseController<Host, ClickButtonRenderProps>
+export class ClickButtonController
+	extends BaseController<ClickButtonRenderProps>
 	implements ControllerInterface<ClickButtonRenderProps, ClickButtonCallbacks, ClickButtonRefs>
 {
 	private buttonRef?: HTMLButtonElement;
 
-	public constructor(component: Host, renderProps: Partial<ClickButtonRenderProps> = {}) {
-		super(component, { label: '', ...renderProps });
+	public constructor() {
+		super({
+			label: '',
+		});
 	}
 
 	public componentWillLoad(props: ClickButtonRenderProps): void {
@@ -22,7 +24,7 @@ export class ClickButtonController<Host extends WebComponentInterface>
 	public watchLabel(value?: LabelPropType): void {
 		const normalized = normalizeLabel(value);
 		if (validateLabel(normalized)) {
-			this.setRenderProp('label', normalized);
+			this.setProp('label', normalized);
 		}
 	}
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
@@ -4,8 +4,8 @@ import { BaseController } from '../base-controller';
 import type { ControllerInterface, WebComponentInterface } from '../generic-types';
 import type { ClickButtonCallbacks, ClickButtonRefs, ClickButtonRenderProps } from './component';
 
-export class ClickButtonController<Host extends WebComponentInterface<ClickButtonRenderProps>>
-	extends BaseController<Host>
+export class ClickButtonController<Host extends WebComponentInterface>
+	extends BaseController<Host, ClickButtonRenderProps>
 	implements ControllerInterface<ClickButtonRenderProps, ClickButtonCallbacks, ClickButtonRefs>
 {
 	private buttonRef?: HTMLButtonElement;
@@ -18,7 +18,7 @@ export class ClickButtonController<Host extends WebComponentInterface<ClickButto
 	public watchLabel(value?: LabelPropType): void {
 		const normalized = normalizeLabel(value);
 		if (validateLabel(normalized)) {
-			this.setRenderPropsOrStates('label', normalized);
+			this.setRenderProps('label', normalized);
 		}
 	}
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
@@ -22,7 +22,7 @@ export class ClickButtonController<Host extends WebComponentInterface>
 	public watchLabel(value?: LabelPropType): void {
 		const normalized = normalizeLabel(value);
 		if (validateLabel(normalized)) {
-			this.renderProps.label = normalized;
+			this.setRenderProp('label', normalized);
 		}
 	}
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
@@ -10,6 +10,10 @@ export class ClickButtonController<Host extends WebComponentInterface>
 {
 	private buttonRef?: HTMLButtonElement;
 
+	public constructor(component: Host) {
+		super(component, { label: '' });
+	}
+
 	public componentWillLoad(props: ClickButtonRenderProps): void {
 		const { label } = props;
 		this.watchLabel(label);
@@ -18,7 +22,7 @@ export class ClickButtonController<Host extends WebComponentInterface>
 	public watchLabel(value?: LabelPropType): void {
 		const normalized = normalizeLabel(value);
 		if (validateLabel(normalized)) {
-			this.setRenderProps('label', normalized);
+			this.renderProps.label = normalized;
 		}
 	}
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
@@ -34,12 +34,11 @@ type ComponentWatchers<Props> = {
 	[K in keyof Props as `watch${Capitalize<string & K>}`]: Callback<Props[K]>;
 };
 
-type RequiredRenderProps<RenderProps> = {
+export type RequiredRenderProps<RenderProps> = {
 	[K in keyof RenderProps]-?: NonNullable<RenderProps[K]>;
 };
 
 export type WebComponentInterface<
-	State,
 	Props = Record<never, never>,
 	Emitters = Record<never, never>,
 	Methods = Record<never, never>,
@@ -48,7 +47,6 @@ export type WebComponentInterface<
 	componentWillLoad(): void;
 } & ComponentProps<Props> &
 	ComponentWatchers<Props> &
-	RequiredRenderProps<State> &
 	WebComponentEmitters<Emitters> &
 	ComponentMethods<Methods> &
 	ComponentListeners<Listeners>;
@@ -84,6 +82,7 @@ export type ControllerInterface<
 	Listeners = Record<never, never>,
 > = {
 	componentWillLoad(props: RequiredRenderProps<RenderProps>): void;
+	getRenderProps(): RequiredRenderProps<RenderProps>;
 } & ComponentWatchers<RenderProps> &
 	ControllerCallbackHandlers<Callbacks> &
 	ControllerRefSetters<Refs> &

--- a/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
@@ -82,7 +82,7 @@ export type ControllerInterface<
 	Listeners = Record<never, never>,
 > = {
 	componentWillLoad(props: RequiredRenderProps<RenderProps>): void;
-	getRenderProps(): RequiredRenderProps<RenderProps>;
+	getProps(): RequiredRenderProps<RenderProps>;
 } & ComponentWatchers<RenderProps> &
 	ControllerCallbackHandlers<Callbacks> &
 	ControllerRefSetters<Refs> &

--- a/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
@@ -34,16 +34,11 @@ type ComponentWatchers<Props> = {
 	[K in keyof Props as `watch${Capitalize<string & K>}`]: Callback<Props[K]>;
 };
 
-export type RequiredRenderProps<RenderProps> = {
-	[K in keyof RenderProps]-?: NonNullable<RenderProps[K]>;
+export type RequiredRenderProps<Props> = {
+	[K in keyof Props]-?: NonNullable<Props[K]>;
 };
 
-export type WebComponentInterface<
-	Props = Record<never, never>,
-	Emitters = Record<never, never>,
-	Methods = Record<never, never>,
-	Listeners = Record<never, never>,
-> = {
+export type WebComponentInterface<Props, Emitters = Record<never, never>, Methods = Record<never, never>, Listeners = Record<never, never>> = {
 	componentWillLoad(): void;
 } & ComponentProps<Props> &
 	ComponentWatchers<Props> &
@@ -75,15 +70,15 @@ type ControllerMethods<Methods> = {
 };
 
 export type ControllerInterface<
-	RenderProps,
+	Props,
 	Callbacks = Record<never, never>,
 	Refs = Record<never, never>,
 	Methods = Record<never, never>,
 	Listeners = Record<never, never>,
 > = {
-	componentWillLoad(props: RequiredRenderProps<RenderProps>): void;
-	getProps(): RequiredRenderProps<RenderProps>;
-} & ComponentWatchers<RenderProps> &
+	componentWillLoad(props: RequiredRenderProps<Props>): void;
+	getProps(): RequiredRenderProps<Props>;
+} & ComponentWatchers<Props> &
 	ControllerCallbackHandlers<Callbacks> &
 	ControllerRefSetters<Refs> &
 	ControllerMethods<Methods> &

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -16,8 +16,8 @@ export class SkeletonController<Host extends WebComponentInterface<Record<never,
 {
 	private readonly clickButtonController: ClickButtonController<Host>;
 
-	public constructor(component: Host) {
-		super(component, { count: 0, label: '', name: '', show: false });
+	public constructor(component: Host, renderProps: Partial<SkeletonRenderProps> = {}) {
+		super(component, { count: 0, label: '', name: '', show: false, ...renderProps });
 		this.clickButtonController = new ClickButtonController<Host>(this.component);
 	}
 
@@ -32,36 +32,36 @@ export class SkeletonController<Host extends WebComponentInterface<Record<never,
 	public watchCount(value?: CountPropType): void {
 		const normalized = normalizeCount(value);
 		if (validateCount(normalized)) {
-			this.renderProps.count = normalized;
+			this.setRenderProp('count', normalized);
 		}
 	}
 
 	public watchLabel(value?: LabelPropType): void {
 		this.clickButtonController.watchLabel(value);
-		this.renderProps.label = this.clickButtonController.getRenderProps().label;
+		this.setRenderProp('label', this.clickButtonController.getRenderProps().label);
 	}
 
 	public watchName(value?: NamePropType): void {
 		const normalized = normalizeName(value);
 		if (validateName(normalized)) {
-			this.renderProps.name = normalized;
+			this.setRenderProp('name', normalized);
 		}
 	}
 
 	public watchShow(value?: ShowPropType): void {
 		const normalized = normalizeShow(value);
 		if (validateShow(normalized)) {
-			this.renderProps.show = normalized;
+			this.setRenderProp('show', normalized);
 		}
 	}
 
 	public toggle(): void {
-		this.renderProps.show = !this.renderProps.show;
+		this.setRenderProp('show', !this.getRenderProps().show);
 	}
 
 	public onKeydown = (event: KeyboardEvent): void => {
 		if (event.key === 'Escape') {
-			this.renderProps.show = false;
+			this.setRenderProp('show', false);
 		}
 	};
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -65,6 +65,8 @@ export class SkeletonController
 
 	public onKeydown = (event: KeyboardEvent): void => {
 		if (event.key === 'Escape') {
+			// eslint-disable-next-line no-console
+			console.log('Show should be toggled');
 			this.setProp('show', false);
 		}
 	};

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -10,10 +10,8 @@ import { ClickButtonController } from '../click-button/controller';
 import type { ControllerInterface, WebComponentInterface } from '../generic-types';
 import type { SkeletonCallbacks, SkeletonEmitters, SkeletonListeners, SkeletonMethods, SkeletonRefs, SkeletonRenderProps } from './component';
 
-export class SkeletonController<
-		Host extends WebComponentInterface<SkeletonRenderProps, Record<never, never>, SkeletonEmitters, SkeletonMethods, SkeletonListeners>,
-	>
-	extends BaseController<Host>
+export class SkeletonController<Host extends WebComponentInterface<Record<never, never>, SkeletonEmitters, SkeletonMethods, SkeletonListeners>>
+	extends BaseController<Host, SkeletonRenderProps>
 	implements ControllerInterface<SkeletonRenderProps, SkeletonCallbacks, SkeletonRefs, SkeletonMethods, SkeletonListeners>
 {
 	private readonly clickButtonController = new ClickButtonController<Host>(this.component);
@@ -29,35 +27,36 @@ export class SkeletonController<
 	public watchCount(value?: CountPropType): void {
 		const normalized = normalizeCount(value);
 		if (validateCount(normalized)) {
-			this.setRenderPropsOrStates('count', normalized);
+			this.setRenderProps('count', normalized);
 		}
 	}
 
 	public watchLabel(value?: LabelPropType): void {
 		this.clickButtonController.watchLabel(value);
+		this.setRenderProps('label', this.clickButtonController.getRenderProps().label);
 	}
 
 	public watchName(value?: NamePropType): void {
 		const normalized = normalizeName(value);
 		if (validateName(normalized)) {
-			this.setRenderPropsOrStates('name', normalized);
+			this.setRenderProps('name', normalized);
 		}
 	}
 
 	public watchShow(value?: ShowPropType): void {
 		const normalized = normalizeShow(value);
 		if (validateShow(normalized)) {
-			this.setRenderPropsOrStates('show', normalized);
+			this.setRenderProps('show', normalized);
 		}
 	}
 
 	public toggle(): void {
-		this.setRenderPropsOrStates('show', !this.component.show);
+		this.setRenderProps('show', !this.renderProps.show);
 	}
 
 	public onKeydown = (event: KeyboardEvent): void => {
 		if (event.key === 'Escape') {
-			this.setRenderPropsOrStates('show', false);
+			this.setRenderProps('show', false);
 		}
 	};
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -18,7 +18,9 @@ export class SkeletonController<Host extends WebComponentInterface<Record<never,
 
 	public constructor(component: Host, renderProps: Partial<SkeletonRenderProps> = {}) {
 		super(component, { count: 0, label: '', name: '', show: false, ...renderProps });
-		this.clickButtonController = new ClickButtonController<Host>(this.component);
+		this.clickButtonController = new ClickButtonController<Host>(this.component, {
+			label: this.getRenderProps().label,
+		});
 	}
 
 	public componentWillLoad(props: SkeletonRenderProps): void {

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -14,7 +14,12 @@ export class SkeletonController<Host extends WebComponentInterface<Record<never,
 	extends BaseController<Host, SkeletonRenderProps>
 	implements ControllerInterface<SkeletonRenderProps, SkeletonCallbacks, SkeletonRefs, SkeletonMethods, SkeletonListeners>
 {
-	private readonly clickButtonController = new ClickButtonController<Host>(this.component);
+	private readonly clickButtonController: ClickButtonController<Host>;
+
+	public constructor(component: Host) {
+		super(component, { count: 0, label: '', name: '', show: false });
+		this.clickButtonController = new ClickButtonController<Host>(this.component);
+	}
 
 	public componentWillLoad(props: SkeletonRenderProps): void {
 		const { count, label, name, show } = props;
@@ -27,36 +32,36 @@ export class SkeletonController<Host extends WebComponentInterface<Record<never,
 	public watchCount(value?: CountPropType): void {
 		const normalized = normalizeCount(value);
 		if (validateCount(normalized)) {
-			this.setRenderProps('count', normalized);
+			this.renderProps.count = normalized;
 		}
 	}
 
 	public watchLabel(value?: LabelPropType): void {
 		this.clickButtonController.watchLabel(value);
-		this.setRenderProps('label', this.clickButtonController.getRenderProps().label);
+		this.renderProps.label = this.clickButtonController.getRenderProps().label;
 	}
 
 	public watchName(value?: NamePropType): void {
 		const normalized = normalizeName(value);
 		if (validateName(normalized)) {
-			this.setRenderProps('name', normalized);
+			this.renderProps.name = normalized;
 		}
 	}
 
 	public watchShow(value?: ShowPropType): void {
 		const normalized = normalizeShow(value);
 		if (validateShow(normalized)) {
-			this.setRenderProps('show', normalized);
+			this.renderProps.show = normalized;
 		}
 	}
 
 	public toggle(): void {
-		this.setRenderProps('show', !this.renderProps.show);
+		this.renderProps.show = !this.renderProps.show;
 	}
 
 	public onKeydown = (event: KeyboardEvent): void => {
 		if (event.key === 'Escape') {
-			this.setRenderProps('show', false);
+			this.renderProps.show = false;
 		}
 	};
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -7,19 +7,21 @@ import type { ShowPropType } from '../../schema/props/show';
 import { normalizeShow, validateShow } from '../../schema/props/show';
 import { BaseController } from '../base-controller';
 import { ClickButtonController } from '../click-button/controller';
-import type { ControllerInterface, WebComponentInterface } from '../generic-types';
-import type { SkeletonCallbacks, SkeletonEmitters, SkeletonListeners, SkeletonMethods, SkeletonRefs, SkeletonRenderProps } from './component';
+import type { ControllerInterface } from '../generic-types';
+import type { SkeletonCallbacks, SkeletonListeners, SkeletonMethods, SkeletonRefs, SkeletonRenderProps } from './component';
 
-export class SkeletonController<Host extends WebComponentInterface<Record<never, never>, SkeletonEmitters, SkeletonMethods, SkeletonListeners>>
-	extends BaseController<Host, SkeletonRenderProps>
+export class SkeletonController
+	extends BaseController<SkeletonRenderProps>
 	implements ControllerInterface<SkeletonRenderProps, SkeletonCallbacks, SkeletonRefs, SkeletonMethods, SkeletonListeners>
 {
-	private readonly clickButtonController: ClickButtonController<Host>;
+	private readonly clickButtonController: ClickButtonController = new ClickButtonController();
 
-	public constructor(component: Host, renderProps: Partial<SkeletonRenderProps> = {}) {
-		super(component, { count: 0, label: '', name: '', show: false, ...renderProps });
-		this.clickButtonController = new ClickButtonController<Host>(this.component, {
-			label: this.getRenderProps().label,
+	public constructor() {
+		super({
+			count: 0,
+			label: '',
+			name: '',
+			show: false,
 		});
 	}
 
@@ -34,36 +36,36 @@ export class SkeletonController<Host extends WebComponentInterface<Record<never,
 	public watchCount(value?: CountPropType): void {
 		const normalized = normalizeCount(value);
 		if (validateCount(normalized)) {
-			this.setRenderProp('count', normalized);
+			this.setProp('count', normalized);
 		}
 	}
 
 	public watchLabel(value?: LabelPropType): void {
 		this.clickButtonController.watchLabel(value);
-		this.setRenderProp('label', this.clickButtonController.getRenderProps().label);
+		this.setProp('label', this.clickButtonController.getProps().label);
 	}
 
 	public watchName(value?: NamePropType): void {
 		const normalized = normalizeName(value);
 		if (validateName(normalized)) {
-			this.setRenderProp('name', normalized);
+			this.setProp('name', normalized);
 		}
 	}
 
 	public watchShow(value?: ShowPropType): void {
 		const normalized = normalizeShow(value);
 		if (validateShow(normalized)) {
-			this.setRenderProp('show', normalized);
+			this.setProp('show', normalized);
 		}
 	}
 
 	public toggle(): void {
-		this.setRenderProp('show', !this.getRenderProps().show);
+		this.setProp('show', !this.getProps().show);
 	}
 
 	public onKeydown = (event: KeyboardEvent): void => {
 		if (event.key === 'Escape') {
-			this.setRenderProp('show', false);
+			this.setProp('show', false);
 		}
 	};
 

--- a/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
@@ -1,6 +1,5 @@
 import type { JSX } from '@stencil/core';
 import { Component, h, Host, Prop, Watch } from '@stencil/core';
-import type { ClickButtonEmitters, ClickButtonRenderProps } from '../../internal/functional-components/click-button/component';
 import { ClickButtonFC } from '../../internal/functional-components/click-button/component';
 import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
@@ -12,13 +11,11 @@ type Props = LabelProp;
 	tag: 'kol-click-button',
 	shadow: true,
 })
-export class KolClickButton implements WebComponentInterface<ClickButtonRenderProps, Props, ClickButtonEmitters> {
+export class KolClickButton implements WebComponentInterface<Props> {
 	private controller = new ClickButtonController<KolClickButton>(this);
 
 	@Prop()
 	public _label!: LabelPropType;
-
-	public label: LabelPropType = '';
 
 	@Watch('_label')
 	public watchLabel(value?: LabelPropType): void {
@@ -32,9 +29,10 @@ export class KolClickButton implements WebComponentInterface<ClickButtonRenderPr
 	}
 
 	public render(): JSX.Element {
+		const { label } = this.controller.getRenderProps();
 		return (
 			<Host>
-				<ClickButtonFC label={this.label} refButton={this.controller.setButtonRef} handleClick={this.controller.handleClick} />
+				<ClickButtonFC label={label} refButton={this.controller.setButtonRef} handleClick={this.controller.handleClick} />
 			</Host>
 		);
 	}

--- a/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
@@ -1,16 +1,17 @@
 import type { JSX } from '@stencil/core';
 import { Component, h, Host, Prop, Watch } from '@stencil/core';
-import type { ClickButtonRenderProps } from '../../internal/functional-components/click-button/component';
 import { ClickButtonFC } from '../../internal/functional-components/click-button/component';
 import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
-import type { LabelPropType } from '../../internal/schema/props/label';
+import type { LabelProp, LabelPropType } from '../../internal/schema/props/label';
+
+type Props = LabelProp;
 
 @Component({
 	tag: 'kol-click-button',
 	shadow: true,
 })
-export class KolClickButton implements WebComponentInterface<ClickButtonRenderProps> {
+export class KolClickButton implements WebComponentInterface<Props> {
 	private readonly controller = new ClickButtonController();
 
 	@Prop()

--- a/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
@@ -1,18 +1,17 @@
 import type { JSX } from '@stencil/core';
 import { Component, h, Host, Prop, Watch } from '@stencil/core';
+import type { ClickButtonRenderProps } from '../../internal/functional-components/click-button/component';
 import { ClickButtonFC } from '../../internal/functional-components/click-button/component';
 import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
-import { type LabelProp, type LabelPropType } from '../../internal/schema/props/label';
-
-type Props = LabelProp;
+import type { LabelPropType } from '../../internal/schema/props/label';
 
 @Component({
 	tag: 'kol-click-button',
 	shadow: true,
 })
-export class KolClickButton implements WebComponentInterface<Props> {
-	private controller = new ClickButtonController<KolClickButton>(this);
+export class KolClickButton implements WebComponentInterface<ClickButtonRenderProps> {
+	private readonly controller = new ClickButtonController();
 
 	@Prop()
 	public _label!: LabelPropType;
@@ -29,7 +28,7 @@ export class KolClickButton implements WebComponentInterface<Props> {
 	}
 
 	public render(): JSX.Element {
-		const { label } = this.controller.getRenderProps();
+		const { label } = this.controller.getProps();
 		return (
 			<Host>
 				<ClickButtonFC label={label} refButton={this.controller.setButtonRef} handleClick={this.controller.handleClick} />

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -4,18 +4,16 @@ import type { WebComponentInterface } from '../../internal/functional-components
 import type { SkeletonEmitters, SkeletonListeners, SkeletonMethods } from '../../internal/functional-components/skeleton/component';
 import { SkeletonFC } from '../../internal/functional-components/skeleton/component';
 import { SkeletonController } from '../../internal/functional-components/skeleton/controller';
-import type { CountProp, CountPropType } from '../../internal/schema/props/count';
-import type { NameProp, NamePropType } from '../../internal/schema/props/name';
-import type { ShowProp, ShowPropType } from '../../internal/schema/props/show';
-
-type Props = CountProp & NameProp & ShowProp;
+import type { CountPropType } from '../../internal/schema/props/count';
+import type { NamePropType } from '../../internal/schema/props/name';
+import type { ShowPropType } from '../../internal/schema/props/show';
 
 @Component({
 	tag: 'kol-skeleton',
 	shadow: true,
 })
-export class KolSkeleton implements WebComponentInterface<Props, SkeletonEmitters, SkeletonMethods, SkeletonListeners> {
-	private controller = new SkeletonController<KolSkeleton>(this, { label: 'Label' });
+export class KolSkeleton implements WebComponentInterface<SkeletonProps, SkeletonEmitters, SkeletonMethods, SkeletonListeners> {
+	private readonly controller = new SkeletonController();
 
 	@Prop()
 	public _count!: CountPropType;
@@ -70,14 +68,14 @@ export class KolSkeleton implements WebComponentInterface<Props, SkeletonEmitter
 	public componentWillLoad(): void {
 		this.controller.componentWillLoad({
 			count: this._count,
-			label: this.controller.getRenderProps().label,
+			label: 'Label',
 			name: this._name,
 			show: this._show,
 		});
 	}
 
 	public render(): JSX.Element {
-		const { count, label, name, show } = this.controller.getRenderProps();
+		const { count, label, name, show } = this.controller.getProps();
 		return (
 			<Host>
 				<SkeletonFC

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -4,15 +4,17 @@ import type { WebComponentInterface } from '../../internal/functional-components
 import type { SkeletonEmitters, SkeletonListeners, SkeletonMethods } from '../../internal/functional-components/skeleton/component';
 import { SkeletonFC } from '../../internal/functional-components/skeleton/component';
 import { SkeletonController } from '../../internal/functional-components/skeleton/controller';
-import type { CountPropType } from '../../internal/schema/props/count';
-import type { NamePropType } from '../../internal/schema/props/name';
-import type { ShowPropType } from '../../internal/schema/props/show';
+import type { CountProp, CountPropType } from '../../internal/schema/props/count';
+import type { NameProp, NamePropType } from '../../internal/schema/props/name';
+import type { ShowProp, ShowPropType } from '../../internal/schema/props/show';
+
+type Props = CountProp & NameProp & ShowProp;
 
 @Component({
 	tag: 'kol-skeleton',
 	shadow: true,
 })
-export class KolSkeleton implements WebComponentInterface<SkeletonProps, SkeletonEmitters, SkeletonMethods, SkeletonListeners> {
+export class KolSkeleton implements WebComponentInterface<Props, SkeletonEmitters, SkeletonMethods, SkeletonListeners> {
 	private readonly controller = new SkeletonController();
 
 	@Prop()

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -1,11 +1,10 @@
 import type { EventEmitter, JSX } from '@stencil/core';
 import { Component, Event, h, Host, Listen, Method, Prop, Watch } from '@stencil/core';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
-import type { SkeletonEmitters, SkeletonListeners, SkeletonMethods, SkeletonRenderProps } from '../../internal/functional-components/skeleton/component';
+import type { SkeletonEmitters, SkeletonListeners, SkeletonMethods } from '../../internal/functional-components/skeleton/component';
 import { SkeletonFC } from '../../internal/functional-components/skeleton/component';
 import { SkeletonController } from '../../internal/functional-components/skeleton/controller';
 import type { CountProp, CountPropType } from '../../internal/schema/props/count';
-import type { LabelPropType } from '../../internal/schema/props/label';
 import type { NameProp, NamePropType } from '../../internal/schema/props/name';
 import type { ShowProp, ShowPropType } from '../../internal/schema/props/show';
 
@@ -15,25 +14,19 @@ type Props = CountProp & NameProp & ShowProp;
 	tag: 'kol-skeleton',
 	shadow: true,
 })
-export class KolSkeleton implements WebComponentInterface<SkeletonRenderProps, Props, SkeletonEmitters, SkeletonMethods, SkeletonListeners> {
+export class KolSkeleton implements WebComponentInterface<Props, SkeletonEmitters, SkeletonMethods, SkeletonListeners> {
 	private controller = new SkeletonController<KolSkeleton>(this);
 
 	@Prop()
 	public _count!: CountPropType;
-
-	public count: CountPropType = 0;
 
 	@Watch('_count')
 	public watchCount(value?: CountPropType): void {
 		this.controller.watchCount(value);
 	}
 
-	public readonly label: LabelPropType = 'Label';
-
 	@Prop()
 	public _name!: NamePropType;
-
-	public name: NamePropType = '';
 
 	@Watch('_name')
 	public watchName(value?: NamePropType): void {
@@ -42,8 +35,6 @@ export class KolSkeleton implements WebComponentInterface<SkeletonRenderProps, P
 
 	@Prop()
 	public _show?: ShowPropType;
-
-	public show: ShowPropType = false;
 
 	@Watch('_show')
 	public watchShow(value?: ShowPropType): void {
@@ -79,22 +70,23 @@ export class KolSkeleton implements WebComponentInterface<SkeletonRenderProps, P
 	public componentWillLoad(): void {
 		this.controller.componentWillLoad({
 			count: this._count,
-			label: this.label,
+			label: 'Label',
 			name: this._name,
 			show: this._show,
 		});
 	}
 
 	public render(): JSX.Element {
+		const { count, label, name, show } = this.controller.getRenderProps();
 		return (
 			<Host>
 				<SkeletonFC
-					count={this.count}
-					label={this.label}
-					name={this.name}
+					count={count}
+					label={label}
+					name={name}
 					handleClick={this.controller.handleClick}
 					onLoaded={this.loaded}
-					show={this.show}
+					show={show}
 					refButton={this.controller.setButtonRef}
 				/>
 			</Host>

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -15,7 +15,7 @@ type Props = CountProp & NameProp & ShowProp;
 	shadow: true,
 })
 export class KolSkeleton implements WebComponentInterface<Props, SkeletonEmitters, SkeletonMethods, SkeletonListeners> {
-	private controller = new SkeletonController<KolSkeleton>(this);
+	private controller = new SkeletonController<KolSkeleton>(this, { label: 'Label' });
 
 	@Prop()
 	public _count!: CountPropType;
@@ -70,7 +70,7 @@ export class KolSkeleton implements WebComponentInterface<Props, SkeletonEmitter
 	public componentWillLoad(): void {
 		this.controller.componentWillLoad({
 			count: this._count,
-			label: 'Label',
+			label: this.controller.getRenderProps().label,
 			name: this._name,
 			show: this._show,
 		});

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -45,6 +45,7 @@ const TAGS = [
 	'kol-progress',
 	'kol-quote',
 	'kol-select',
+	'kol-skeleton',
 	'kol-skip-nav',
 	'kol-spin',
 	'kol-split-button',

--- a/packages/samples/react/src/components/abbr/basic.tsx
+++ b/packages/samples/react/src/components/abbr/basic.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { KolAbbr } from '@public-ui/react';
+import { KolAbbr, KolSkeleton } from '@public-ui/react';
 import { SampleDescription } from '../SampleDescription';
 
 import type { FC } from 'react';
@@ -16,6 +16,10 @@ export const AbbrBasic: FC = () => (
 
 		<p>
 			I am <KolAbbr>e.g.</KolAbbr> an abbreviation without label.
+		</p>
+
+		<p>
+			<KolSkeleton _count={3} _name="Example" _show={true} />
 		</p>
 	</>
 );


### PR DESCRIPTION
## Summary
- refactor generic types to manage render props solely in controllers
- keep render props in controllers with getRenderProps in base controller
- update skeleton and click-button examples to use controller-managed render props

## Testing
- `pnpm format -w`
- `pnpm build`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688f92e85858832b803a0b258db1fefc