### PR TITLE
docs: update skeleton component docs

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -95,14 +95,5 @@ When refactoring or adding a component:
 2. Replace class strings with calls to the generated `bem` helper.
 3. Export the schema constant via `src/index.ts` to enable SCSS generation.
 
-## Component and Controller Architecture (Skeleton Blueprint)
-
-The `_skeleton` component demonstrates the recommended pattern for combining a Stencil web component with a stateless functional component and a controller. Key aspects are:
-
-1. Public `@Prop` values mirror to private `@State` variables named `<prop>`.
-2. Each property has a `@Watch` method that normalizes and validates the value using helpers from `internal/functional-components/.../schema/props`. Valid values update state via `controller.setState()`.
-3. `componentWillLoad` calls every watcher once to initialise state.
-4. Business logic lives in a controller extending `BaseController` which only exposes methods to update state or manage refs.
-5. The `render()` method delegates to a stateless functional component, forwarding the current state, `EventEmitter`s and controller callbacks.
-
-Use this blueprint when adding new components.
+For architectural guidance when creating new components, consult
+[`src/components/_skeleton/ARC42.md`](src/components/_skeleton/ARC42.md).

--- a/packages/components/src/components/_skeleton/AGENTS.md
+++ b/packages/components/src/components/_skeleton/AGENTS.md
@@ -1,96 +1,16 @@
-# Component Architecture Blueprint
+# Agent Instructions
 
-## Design Philosophy
+This directory contains the `kol` skeleton component blueprint. For
+architectural and design details, see [ARC42.md](./ARC42.md).
 
-This skeleton demonstrates **Separation of Concerns** through layered architecture, where each layer has a single responsibility and clear boundaries.
+## Guidelines for KI Agents
 
-## Layer Responsibilities
-
-- **Web component** – public API surface. Incoming `@Prop` values are exposed with a leading `_` (e.g. `_count`). `@Watch` decorators must observe the underscored props (for example `@Watch('_count')`) to normalise and validate external values before delegating to the controller. Render props are accessed via `controller.getRenderProps()` instead of mirroring them locally.
-- **Controller** – encapsulates business logic and state transitions. It coordinates prop watchers, updates render props directly and can compose other controllers for additional behaviour.
-- **Functional component** – pure, stateless renderer that receives the current state snapshot together with callbacks, emitters and refs. It never mutates data and communicates through events.
-- **Schema utilities** – prop type declarations plus `normalize*/validate*` helpers that keep domain rules close to the data model.
-
-## Data Flow
-
-1. External consumers set public props (`_count`, `_name`, ...).
-2. Prop watchers on the underscored fields invoke schema helpers to normalise and validate values.
-3. The controller updates internal state or render props.
-4. The functional component renders based on that state and emits events back to the outside.
-
-This unidirectional flow keeps state predictable and makes cross‑layer responsibilities explicit.
-
-## Architectural Patterns
-
-### 1. Layered Architecture
-
-- **Presentation Layer**: Stencil web components (public API)
-- **Business Logic Layer**: Controllers (state management, validation)
-- **Data Layer**: Functional components (pure rendering)
-
-### 2. Composition over Inheritance
-
-Controllers compose behavior rather than inheriting it. Each controller focuses on one responsibility and can be combined with others.
-
-### 3. Immutable Data Flow
-
-Data flows only from the public API towards the renderer. There are no backwards mutations; controllers toggle state by replacing values.
-
-### 4. Type Safety Boundaries
-
-Generic types enforce compile‑time guarantees about render props, eliminating defensive programming in functional components.
-
-## Implementation Concepts
-
-### State Ownership Principle
-
-Web components own state, controllers manage state transitions, functional components consume state. This creates clear ownership boundaries and predictable data flow.
-
-### Event-Driven Communication
-
-Components communicate through events rather than direct coupling, maintaining loose coupling and enabling composition.
-
-### Declarative Rendering
-
-Functional components receive complete state snapshots and render declaratively, eliminating imperative DOM manipulation.
-
-### Watcher Placement
-
-Attach `@Watch` only to the underscored public props (`_count`, `_name`, ...). Internal state fields like `count`, `name`, `show` or `label` stay undecorated because watchers do not trigger on plain class properties.
-
-### Controller Initialization Pattern
-
-Web components must initialize controllers by passing current render props to ensure proper state setup:
-
-```typescript
-public componentWillLoad(): void {
-  this.controller.componentWillLoad({
-    count: this._count,
-    name: this._name,
-  });
-}
-```
-
-This ensures controllers receive the complete current state before any external prop changes occur.
-
-## Design Patterns
-
-### Generic Type System
-
-The component uses generic interfaces to enforce **compile-time contracts**. This eliminates runtime errors by ensuring all required properties have defaults before rendering.
-
-### Controller Pattern
-
-Controllers implement the **Single Responsibility Principle**. Each controller manages one aspect of component behavior (state, validation, DOM refs) and can be composed together.
-
-### Functional Component Architecture
-
-Rendering logic lives in **pure functions** that receive immutable props. This enables predictable output, easy testing, and better performance through memoization.
-
-## Usage Example
-
-```html
-<kol-skeleton _count="42" _name="Example"></kol-skeleton>
-```
-
-The component demonstrates how web standards (Custom Elements, Shadow DOM) can be enhanced with modern TypeScript patterns to create maintainable, type-safe UI components.
+- Controllers encapsulate state transitions and expose `getRenderProps()` for
+  rendering.
+- Functional components are stateless and render based on the controller's
+  props.
+- Initialize the controller in `componentWillLoad` using the current `_count`
+  and `_name`.
+- Public props use a leading `_` (for example `_count`) and mirror to internal
+  fields without the underscore.
+- Watchers attach only to these underscored props.

--- a/packages/components/src/components/_skeleton/AGENTS.md
+++ b/packages/components/src/components/_skeleton/AGENTS.md
@@ -13,7 +13,7 @@ This skeleton demonstrates **Separation of Concerns** through layered architectu
 
 ## Data Flow
 
-1. External consumers set public props (`_count`, `_name`, `_show`, ...).
+1. External consumers set public props (`_count`, `_name`, ...).
 2. Prop watchers on the underscored fields invoke schema helpers to normalise and validate values.
 3. The controller updates internal state or render props.
 4. The functional component renders based on that state and emits events back to the outside.
@@ -56,7 +56,7 @@ Functional components receive complete state snapshots and render declaratively,
 
 ### Watcher Placement
 
-Attach `@Watch` only to the underscored public props (`_count`, `_name`, `_show`, ...). Internal state fields like `count`, `name`, `show` or `label` stay undecorated because watchers do not trigger on plain class properties.
+Attach `@Watch` only to the underscored public props (`_count`, `_name`, ...). Internal state fields like `count`, `name`, `show` or `label` stay undecorated because watchers do not trigger on plain class properties.
 
 ### Controller Initialization Pattern
 
@@ -66,9 +66,7 @@ Web components must initialize controllers by passing current render props to en
 public componentWillLoad(): void {
   this.controller.componentWillLoad({
     count: this._count,
-    label: 'Label',
     name: this._name,
-    show: this._show,
   });
 }
 ```
@@ -92,7 +90,7 @@ Rendering logic lives in **pure functions** that receive immutable props. This e
 ## Usage Example
 
 ```html
-<kol-skeleton _count="42" _name="Example" _show="true"></kol-skeleton>
+<kol-skeleton _count="42" _name="Example"></kol-skeleton>
 ```
 
 The component demonstrates how web standards (Custom Elements, Shadow DOM) can be enhanced with modern TypeScript patterns to create maintainable, type-safe UI components.

--- a/packages/components/src/components/_skeleton/ARC42.md
+++ b/packages/components/src/components/_skeleton/ARC42.md
@@ -17,6 +17,12 @@ Primary goals:
 - enable replacement or extension of layers without cascading changes
 - enforce consistent validation and type-safety boundaries
 
+### Usage Example
+
+```html
+<kol-skeleton _count="42" _name="Example"></kol-skeleton>
+```
+
 ## 2. Architecture Constraints
 
 - **Stencil** is used for authoring web components.
@@ -41,10 +47,10 @@ flowchart LR
 
 The blueprint enforces unidirectional data flow and delegates responsibilities to isolated layers:
 
-- Web components expose a stable public API and mirror underscored props to private fields.
-- Controllers own business logic, normalization and validation.
-- Functional components render pure JSX based on provided props.
-- Schema helpers define canonical prop types and validation rules close to the data model.
+- **Controller** – encapsulates business logic and state transitions. It coordinates prop watchers, updates render props and can compose other controllers for additional behaviour.
+- **Functional component** – pure, stateless renderer that receives the current state snapshot together with callbacks, emitters and refs. It never mutates data and communicates through events.
+- **Schema helpers** – prop type declarations plus `normalize*/validate*` helpers that keep domain rules close to the data model.
+- **Web component** – public API surface. Incoming `@Prop` values are exposed with a leading `_` (e.g. `_count`). `@Watch` decorators must observe the underscored props to normalise and validate external values before delegating to the controller. Render props are accessed via `controller.getRenderProps()` instead of mirroring them locally.
 
 ### Props Pattern
 
@@ -71,6 +77,21 @@ public watchCount(value?: CountPropType): void {
 ```
 
 See the [controller](./internal/functional-components/skeleton/controller.ts) for the corresponding validation logic.
+
+### Controller Initialization
+
+Web components must initialise controllers by passing the current render props to ensure proper state setup:
+
+```ts
+public componentWillLoad(): void {
+  this.controller.componentWillLoad({
+    count: this._count,
+    name: this._name,
+  });
+}
+```
+
+This ensures controllers receive the complete current state before any external prop changes occur.
 
 ## 5. Building Block View
 
@@ -128,11 +149,15 @@ The skeleton ships as part of the `@public-ui/components` package. During build 
 
 ## 8. Cross-cutting Concepts
 
+- **Composition over inheritance**: Controllers compose behaviour rather than relying on inheritance.
+- **Declarative rendering**: Functional components are pure and stateless.
 - **Decoupling**: Each layer only knows its direct neighbours. Controllers can be reused or replaced without altering renderers or schemas.
-- **Template Method Pattern**: The WebComponent defines the overall component lifecycle and structure (template), while the Controller implements the specific business logic steps. The WebComponent provides itself as a reference to the Controller, allowing the Controller to modify the component's state during the execution of the template.
 - **Event-driven communication**: User interaction is emitted as DOM events rather than calling functions across layers.
-- **Type safety**: Generics enforce compile-time contracts between components and controllers.
 - **Props Pattern**: Functional components exclusively receive Props that contain either normalized/validated external data or internal component state. Props must always be initialized to prevent rendering with undefined values. This guarantees that rendering logic never operates on raw, unvalidated inputs and maintains data integrity throughout the component lifecycle.
+- **State ownership**: Web components own state, controllers manage transitions and functional components consume state.
+- **Template Method Pattern**: The WebComponent defines the overall component lifecycle and structure (template), while the Controller implements the specific business logic steps. The WebComponent provides itself as a reference to the Controller, allowing the Controller to modify the component's state during the execution of the template.
+- **Type safety**: Generics enforce compile-time contracts between components and controllers.
+- **Watcher placement**: Attach `@Watch` only to underscored public props; internal state fields remain undecorated.
 
 ## 9. Design Decisions
 

--- a/packages/components/src/components/_skeleton/internal/schema/props/README.md
+++ b/packages/components/src/components/_skeleton/internal/schema/props/README.md
@@ -31,13 +31,11 @@ if (validateValue(normalized)) {
 
 ## Initialization Contract
 
-Controllers expect complete render props during initialization to establish consistent state:
+Controllers expect the current values of render props during initialization to establish consistent state. Internal state fields are handled separately:
 
 ```typescript
 this.controller.componentWillLoad({
-	count: this.count, // Current render prop values
-	label: this.label, // with guaranteed defaults
-	name: this.name, // from component initialization
-	show: this.show,
+	count: this._count, // Current render prop values
+	name: this._name, // from component initialization
 });
 ```


### PR DESCRIPTION
## Summary
- remove obsolete `_show` references from skeleton blueprint
- clarify controller initialization contract in skeleton schema docs

## Testing
- `npx prettier packages/components/src/components/_skeleton/AGENTS.md packages/components/src/components/_skeleton/internal/schema/props/README.md packages/components/src/components/_skeleton/ARC42.md -w`


------
https://chatgpt.com/codex/tasks/task_e_68903b09ff38832ba744b856245d5b36