### PR TITLE
fix(samples): move skeleton demo to scenario

### DIFF
--- a/packages/samples/react/src/components/abbr/basic.tsx
+++ b/packages/samples/react/src/components/abbr/basic.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { KolAbbr, KolSkeleton } from '@public-ui/react';
+import { KolAbbr } from '@public-ui/react';
 import { SampleDescription } from '../SampleDescription';
 
 import type { FC } from 'react';
@@ -16,10 +16,6 @@ export const AbbrBasic: FC = () => (
 
 		<p>
 			I am <KolAbbr>e.g.</KolAbbr> an abbreviation without label.
-		</p>
-
-		<p>
-			<KolSkeleton _count={3} _name="Example" _show={true} />
 		</p>
 	</>
 );

--- a/packages/samples/react/src/scenarios/routes.ts
+++ b/packages/samples/react/src/scenarios/routes.ts
@@ -10,6 +10,7 @@ import { SameHeightOfAllInteractiveElements } from './same-height-of-all-interac
 import { StaticForm } from './static-form';
 import { TableHorizontalScrollAdvanced } from './horizontal-scrollbar-advanced';
 import { TooltipPositioning } from './tooltip-positioning';
+import { Skeleton } from './skeleton';
 
 export const SCENARIO_ROUTES: Routes = {
 	scenarios: {
@@ -24,5 +25,6 @@ export const SCENARIO_ROUTES: Routes = {
 		'static-form': StaticForm,
 		'table-horizontal-scrollbar-advanced': TableHorizontalScrollAdvanced,
 		'tooltip-positioning': TooltipPositioning,
+		skeleton: Skeleton,
 	},
 };

--- a/packages/samples/react/src/scenarios/skeleton.tsx
+++ b/packages/samples/react/src/scenarios/skeleton.tsx
@@ -1,0 +1,20 @@
+import React, { useRef } from 'react';
+import type { FC } from 'react';
+
+import { KolButton, KolSkeleton } from '@public-ui/react';
+import { SampleDescription } from '../components/SampleDescription';
+
+export const Skeleton: FC = () => {
+	const skeletonRef = useRef<HTMLKolSkeletonElement>(null);
+
+	return (
+		<>
+			<SampleDescription>
+				<p>KolSkeleton can be toggled to display loading placeholders.</p>
+			</SampleDescription>
+
+			<KolButton _label="Toggle" onClick={() => skeletonRef.current?.toggle()} />
+			<KolSkeleton _count={3} _name="Example" ref={skeletonRef} />
+		</>
+	);
+};


### PR DESCRIPTION
## Summary
- remove invalid `KolSkeleton` usage from Abbr sample
- add `KolSkeleton` scenario demonstrating toggle
- register scenario in routes

## Testing
- `pnpm --filter @public-ui/sample-react build`
- `pnpm --filter @public-ui/sample-react lint`
- `pnpm --filter @public-ui/sample-react test` *(fails: `ELIFECYCLE Command failed with exit code 1` after tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_6890c0bcf65c832b98b635817103b3d7