### PR TITLE
refactor(components): rely on click handler for skeleton button

### DIFF
--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/component.tsx
@@ -19,15 +19,7 @@ export type ClickButtonRenderStates = Record<never, never>;
 type Props = FunctionalComponentProps<ClickButtonRenderProps, ClickButtonRenderStates, ClickButtonCallbacks, ClickButtonEmitters, ClickButtonRefs>;
 
 export const ClickButtonFC: FC<Props> = ({ label, handleClick, refButton }) => (
-	<button
-		ref={refButton}
-		onClick={handleClick}
-		onKeyDown={(event): void => {
-			if (event.key === 'Enter' || event.key === ' ') {
-				handleClick();
-			}
-		}}
-	>
+	<button ref={refButton} onClick={handleClick}>
 		{label}
 	</button>
 );

--- a/packages/components/src/components/_skeleton/web-components/click-button/test/click.spec.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/test/click.spec.tsx
@@ -1,0 +1,16 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { KolClickButton } from '../component';
+
+describe('KolClickButton', () => {
+	it('calls handleClick when clicked', async () => {
+		const page = await newSpecPage({
+			components: [KolClickButton],
+			html: `<kol-click-button _label="Click"></kol-click-button>`,
+		});
+		const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+		const button = page.root!.shadowRoot!.querySelector('button')!;
+		button.click();
+		expect(logSpy).toHaveBeenCalled();
+		logSpy.mockRestore();
+	});
+});


### PR DESCRIPTION
## Summary
- remove redundant `onKeyDown` handling from skeleton `ClickButton` component
- add unit test verifying click invokes handler

## Testing
- `pnpm --filter @public-ui/components build`
- `pnpm --filter @public-ui/components lint`
- `pnpm --filter @public-ui/components test`


------
https://chatgpt.com/codex/tasks/task_e_6890ebc0489c832bab55f39c301d3316