### PR TITLE
feat(components): inject skeleton subcontroller

### DIFF
--- a/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
@@ -91,7 +91,3 @@ export type ControllerInterface<
 	ControllerRefSetters<Refs> &
 	ControllerMethods<Methods> &
 	ControllerListeners<Listeners>;
-
-export type ControllerFactories<Controllers> = {
-	[K in keyof Controllers as `create${Capitalize<string & K>}Controller`]: (component: WebComponentInterface) => Controllers[K];
-};

--- a/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
@@ -91,3 +91,7 @@ export type ControllerInterface<
 	ControllerRefSetters<Refs> &
 	ControllerMethods<Methods> &
 	ControllerListeners<Listeners>;
+
+export type ControllerFactories<Controllers> = {
+	[K in keyof Controllers as `create${Capitalize<string & K>}Controller`]: (component: WebComponentInterface) => Controllers[K];
+};

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.spec.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import type { WebComponentInterface } from '../generic-types';
+import type { SkeletonRenderStates } from './component';
+import type { ClickButtonController } from '../click-button/controller';
+import { SkeletonController } from './controller';
+
+describe('SkeletonController', () => {
+	it('delegates focusButton to injected ClickButtonController', () => {
+		const component = { show: true } as WebComponentInterface<Record<never, never>, SkeletonRenderStates>;
+		const clickButtonController = {
+			focusButton: jest.fn(),
+			setButtonRef: jest.fn(),
+			componentWillLoad: jest.fn(),
+		} as unknown as ClickButtonController;
+		const controller = new SkeletonController(component, {
+			createClickButtonController: () => clickButtonController,
+		});
+
+		controller.focusButton();
+
+		expect(clickButtonController.focusButton).toHaveBeenCalled();
+	});
+});

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.spec.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.spec.ts
@@ -12,9 +12,7 @@ describe('SkeletonController', () => {
 			setButtonRef: jest.fn(),
 			componentWillLoad: jest.fn(),
 		} as unknown as ClickButtonController;
-		const controller = new SkeletonController(component, {
-			createClickButtonController: () => clickButtonController,
-		});
+		const controller = new SkeletonController(component, clickButtonController);
 
 		controller.focusButton();
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -4,8 +4,8 @@ import type { LabelPropType } from '../../schema/props/label';
 import type { NamePropType } from '../../schema/props/name';
 import { normalizeName, validateName } from '../../schema/props/name';
 import { BaseController } from '../base-controller';
-import { ClickButtonController } from '../click-button/controller';
-import type { ControllerInterface, WebComponentInterface } from '../generic-types';
+import type { ClickButtonController } from '../click-button/controller';
+import type { ControllerFactories, ControllerInterface, WebComponentInterface } from '../generic-types';
 import type { SkeletonCallbacks, SkeletonListeners, SkeletonMethods, SkeletonRefs, SkeletonRenderProps, SkeletonRenderStates } from './component';
 
 export class SkeletonController
@@ -16,12 +16,15 @@ export class SkeletonController
 
 	public label: LabelPropType = 'Label';
 
-	public constructor(component: WebComponentInterface<Record<never, never>, SkeletonRenderStates>) {
+	public constructor(
+		component: WebComponentInterface<Record<never, never>, SkeletonRenderStates>,
+		controllers: ControllerFactories<{ clickButton: ClickButtonController }>,
+	) {
 		super(component, {
 			count: 0,
 			name: '',
 		});
-		this.clickButtonController = new ClickButtonController(component);
+		this.clickButtonController = controllers.createClickButtonController(component);
 	}
 
 	public componentWillLoad(props: SkeletonRenderProps): void {

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -5,7 +5,7 @@ import type { NamePropType } from '../../schema/props/name';
 import { normalizeName, validateName } from '../../schema/props/name';
 import { BaseController } from '../base-controller';
 import type { ClickButtonController } from '../click-button/controller';
-import type { ControllerFactories, ControllerInterface, WebComponentInterface } from '../generic-types';
+import type { ControllerInterface, WebComponentInterface } from '../generic-types';
 import type { SkeletonCallbacks, SkeletonListeners, SkeletonMethods, SkeletonRefs, SkeletonRenderProps, SkeletonRenderStates } from './component';
 
 export class SkeletonController
@@ -16,15 +16,12 @@ export class SkeletonController
 
 	public label: LabelPropType = 'Label';
 
-	public constructor(
-		component: WebComponentInterface<Record<never, never>, SkeletonRenderStates>,
-		controllers: ControllerFactories<{ clickButton: ClickButtonController }>,
-	) {
+	public constructor(component: WebComponentInterface<Record<never, never>, SkeletonRenderStates>, clickButtonController: ClickButtonController) {
 		super(component, {
 			count: 0,
 			name: '',
 		});
-		this.clickButtonController = controllers.createClickButtonController(component);
+		this.clickButtonController = clickButtonController;
 	}
 
 	public componentWillLoad(props: SkeletonRenderProps): void {

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -12,16 +12,16 @@ export class SkeletonController
 	extends BaseController<SkeletonRenderProps, SkeletonRenderStates>
 	implements ControllerInterface<SkeletonRenderProps, SkeletonCallbacks, SkeletonRefs, SkeletonMethods, SkeletonListeners>
 {
-	private readonly clickButtonController: ClickButtonController;
-
 	public label: LabelPropType = 'Label';
 
-	public constructor(component: WebComponentInterface<Record<never, never>, SkeletonRenderStates>, clickButtonController: ClickButtonController) {
+	public constructor(
+		component: WebComponentInterface<Record<never, never>, SkeletonRenderStates>,
+		private readonly clickButtonController: ClickButtonController,
+	) {
 		super(component, {
 			count: 0,
 			name: '',
 		});
-		this.clickButtonController = clickButtonController;
 	}
 
 	public componentWillLoad(props: SkeletonRenderProps): void {

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -1,5 +1,6 @@
 import type { EventEmitter, JSX } from '@stencil/core';
 import { Component, Event, h, Host, Listen, Method, Prop, State, Watch } from '@stencil/core';
+import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
 import type {
 	SkeletonEmitters,
@@ -10,7 +11,6 @@ import type {
 } from '../../internal/functional-components/skeleton/component';
 import { SkeletonFC } from '../../internal/functional-components/skeleton/component';
 import { SkeletonController } from '../../internal/functional-components/skeleton/controller';
-import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
 import type { CountPropType } from '../../internal/schema/props/count';
 import type { LabelPropType } from '../../internal/schema/props/label';
 import type { NamePropType } from '../../internal/schema/props/name';
@@ -21,9 +21,7 @@ import type { ShowPropType } from '../../internal/schema/props/show';
 	shadow: true,
 })
 export class KolSkeleton implements WebComponentInterface<SkeletonRenderProps, SkeletonRenderStates, SkeletonEmitters, SkeletonMethods, SkeletonListeners> {
-	private readonly controller = new SkeletonController(this, {
-		createClickButtonController: (component) => new ClickButtonController(component),
-	});
+	private readonly controller = new SkeletonController(this, new ClickButtonController(this));
 
 	@Prop()
 	public _count!: CountPropType;

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -10,6 +10,7 @@ import type {
 } from '../../internal/functional-components/skeleton/component';
 import { SkeletonFC } from '../../internal/functional-components/skeleton/component';
 import { SkeletonController } from '../../internal/functional-components/skeleton/controller';
+import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
 import type { CountPropType } from '../../internal/schema/props/count';
 import type { LabelPropType } from '../../internal/schema/props/label';
 import type { NamePropType } from '../../internal/schema/props/name';
@@ -20,7 +21,9 @@ import type { ShowPropType } from '../../internal/schema/props/show';
 	shadow: true,
 })
 export class KolSkeleton implements WebComponentInterface<SkeletonRenderProps, SkeletonRenderStates, SkeletonEmitters, SkeletonMethods, SkeletonListeners> {
-	private readonly controller = new SkeletonController(this);
+	private readonly controller = new SkeletonController(this, {
+		createClickButtonController: (component) => new ClickButtonController(component),
+	});
 
 	@Prop()
 	public _count!: CountPropType;

--- a/packages/samples/react/src/scenarios/skeleton.tsx
+++ b/packages/samples/react/src/scenarios/skeleton.tsx
@@ -14,6 +14,7 @@ export const Skeleton: FC = () => {
 			</SampleDescription>
 
 			<KolButton _label="Toggle" onClick={() => skeletonRef.current?.toggle()} />
+			<KolButton _label="Focus Button" onClick={() => skeletonRef.current?.focusButton()} />
 			<KolSkeleton _count={3} _name="Example" ref={skeletonRef} />
 		</>
 	);


### PR DESCRIPTION
## Summary
- add `ControllerFactories` to generic types for dependency injection
- inject `ClickButtonController` into `SkeletonController` via factory
- expose controller injection in samples and tests

## Testing
- `pnpm --filter @public-ui/components build`
- `pnpm --filter @public-ui/components lint`
- `pnpm --filter @public-ui/components test:unit packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_6890ed9852a0832b8f9df59e3db10ad2