### PR TITLE
feat(components): allow setting runtime mode via register

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ import { register } from '@public-ui/components';
 import { defineCustomElements } from '@public-ui/components/dist/loader';
 import { DEFAULT } from '@public-ui/theme-default';
 
-register(DEFAULT, defineCustomElements);
+register(DEFAULT, defineCustomElements, { mode: 'development' });
 ```
+
+Provide the `mode` option to explicitly set the runtime environment (`development`, `test` or `production`).
 
 ## Collaboration and cooperation
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -33,8 +33,10 @@ import { register } from '@public-ui/components';
 import { defineCustomElements } from '@public-ui/components/dist/loader';
 import { DEFAULT } from '@public-ui/theme-default';
 
-register(DEFAULT, defineCustomElements).catch(console.error);
+register(DEFAULT, defineCustomElements, { mode: 'development' }).catch(console.error);
 ```
+
+The optional third argument accepts a `mode` property to set the runtime environment (`development`, `test` or `production`).
 
 After registration you can use the elements in your markup:
 

--- a/packages/components/src/components/README.md
+++ b/packages/components/src/components/README.md
@@ -19,7 +19,7 @@ import { defineCustomElements } from '@public-ui/components/dist/loader';
 import { register } from '@public-ui/components';
 import { DEFAULT } from '@public-ui/theme-default';
 
-register(DEFAULT, defineCustomElements)
+register(DEFAULT, defineCustomElements, { mode: 'development' })
 	.then(() => {
 		/* KoliBri ready */
 	})
@@ -27,6 +27,8 @@ register(DEFAULT, defineCustomElements)
 		/* Handle errors */
 	});
 ```
+
+Pass the optional `mode` to select the runtime environment (`development`, `test` or `production`).
 
 Then, you can use the components in your HTML:
 

--- a/packages/components/src/core/bootstrap.ts
+++ b/packages/components/src/core/bootstrap.ts
@@ -1,5 +1,6 @@
 import type { Generic, LoaderCallback, RegisterOptions } from 'adopted-style-sheets';
 import { register as coreRegister } from 'adopted-style-sheets';
+import { setRuntimeMode, type Mode } from '../schema/utils/reuse';
 import { setCustomTagNames } from './component-names';
 import { initializeI18n } from './i18n';
 
@@ -13,6 +14,11 @@ type KoliBriOptions = RegisterOptions & {
 	 * When enabled, all input fields will reflect their current value to the host element, making it accessible outside the shadow DOM.
 	 */
 	reflectInputValues?: boolean;
+
+	/**
+	 * Set the runtime mode of the library. Defaults to 'production'.
+	 */
+	mode?: Mode;
 };
 
 let initialized = false;
@@ -26,6 +32,9 @@ export const bootstrap = async (
 	loaders: LoaderCallback | LoaderCallback[] | Set<LoaderCallback>,
 	koliBriOptions?: KoliBriOptions,
 ): Promise<void[]> => {
+	if (koliBriOptions?.mode) {
+		setRuntimeMode(koliBriOptions.mode);
+	}
 	initializeI18n(koliBriOptions?.translation?.name ?? 'de', koliBriOptions?.translations);
 	if (koliBriOptions?.transformTagName) {
 		setCustomTagNames(koliBriOptions?.transformTagName);

--- a/packages/components/src/schema/utils/dev.utils.ts
+++ b/packages/components/src/schema/utils/dev.utils.ts
@@ -69,11 +69,6 @@ export class Logger {
 		private readonly label: string,
 		private readonly devMode: GetModeFn,
 	) {
-		/**
-		 * Should remove within the pull request would be finished.
-		 */
-		console.log('🔍 Environment Debug - NODE_ENV (Lib):', runtimeMode);
-
 		if (this.devMode()) {
 			this.info('Development mode active - Enhanced debugging features available');
 		}

--- a/packages/components/src/schema/utils/reuse.ts
+++ b/packages/components/src/schema/utils/reuse.ts
@@ -8,6 +8,10 @@ try {
 	runtimeMode = 'production';
 }
 
+export const setRuntimeMode = (mode: Mode): void => {
+	runtimeMode = mode;
+};
+
 /**
  * This function is used to handle the slot content by
  * moving a DOM element to a defined slot element.


### PR DESCRIPTION
## Summary
- allow passing runtime mode via `register` options
- add runtime mode setter
- document `mode` option and clean up debug logging

## Testing
- `pnpm --filter @public-ui/components build`
- `pnpm --filter @public-ui/components lint`
- `pnpm --filter @public-ui/components test` *(fails: 386 snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6899e5481640832b99ced25ba85902f9