### PR TITLE
feat: add KERN-UX theme to React sample app

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,6 @@
 		"test-update": "pnpm -r test-update",
 		"update": "pnpm ncu:minor && pnpm ncu:major",
 		"version": "node scripts/update-publiccode.mjs && git add publiccode.yml"
-	}
+	},
+	"packageManager": "pnpm@10.18.3+sha512.bbd16e6d7286fd7e01f6b3c0b3c932cda2965c06a908328f74663f10a9aea51f1129eea615134bf992831b009eabe167ecb7008b597f40ff9bc75946aadfb08d"
 }

--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -17,7 +17,7 @@
 		"lint:tsc": "tsc --noemit",
 		"prepare": "npm-run-all2 prepare:*",
 		"prepare:components": "cpy \"node_modules/@public-ui/components/assets/**/*\" public/assets --dot",
-		"prepare:themes": "cpy \"node_modules/@public-ui/themes/assets/**/*\" public/assets --dot",
+                "prepare:themes": "cpy \"node_modules/@kern-ux-annex/theme-kolibri/assets/**/*\" \"node_modules/@public-ui/themes/assets/**/*\" public/assets --dot",
 		"serve": "vite",
 		"start": "vite --open",
 		"test": "pnpm test:e2e",
@@ -25,8 +25,9 @@
 		"unused": "knip"
 	},
 	"dependencies": {
-		"@hookform/resolvers": "5.2.2",
-		"@leanup/stack": "1.3.54",
+                "@hookform/resolvers": "5.2.2",
+                "@kern-ux-annex/theme-kolibri": "2.3.2",
+                "@leanup/stack": "1.3.54",
 		"@playwright/test": "1.56.0",
 		"@public-ui/components": "workspace:*",
 		"@public-ui/react-hook-form-adapter": "workspace:*",

--- a/packages/samples/react/src/react.main.tsx
+++ b/packages/samples/react/src/react.main.tsx
@@ -1,3 +1,4 @@
+import { KERN_V2 } from '@kern-ux-annex/theme-kolibri';
 import { setTagNameTransformer } from '@public-ui/react-v19';
 import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -12,6 +13,7 @@ import { App } from './App';
 import type { Generic } from 'adopted-style-sheets';
 
 type Theme = Generic.Theming.RegisterPatch<string, string, string>;
+type PatchTheme = (name: string, patches: Record<string, string>, options?: { append?: boolean }) => void;
 
 const ENABLE_I18N_OVERWRITING =
 	process.env.ENABLE_I18N_OVERWRITING === 'true' || new URL('https://x' + location.hash.substring(1)).searchParams.has('enableI18nOverwriting');
@@ -40,7 +42,7 @@ const getThemes = async () => {
 	}
 
 	/* List of regular sample app themes */
-	return [DEFAULT, ECL_EC, ECL_EU] as Theme[];
+	return [DEFAULT, ECL_EC, ECL_EU, KERN_V2] as Theme[];
 };
 
 void (async () => {
@@ -90,25 +92,30 @@ void (async () => {
 		 * You should patch the theme after the components and your default theme are registered.
 		 */
 		if (ENABLE_THEME_PATCHING) {
-			KoliBriDevHelper.patchTheme(
-				'default',
-				{
-					'KOL-BUTTON': `
-						button {
-							border: 1px solid red;
-						}`,
-					'KOL-SPIN': `
-						.bg-spin-2 {
-							background-color: red;
-						}
-						.bg-spin-3 {
-							background-color: gold;
-						}`,
-				},
-				{
-					append: true,
-				},
-			);
+			const { patchTheme } = KoliBriDevHelper as { patchTheme?: PatchTheme };
+			if (typeof patchTheme === 'function') {
+				patchTheme(
+					'default',
+					{
+						'KOL-BUTTON': `
+							button {
+								border: 1px solid red;
+							}
+						`,
+						'KOL-SPIN': `
+							.bg-spin-2 {
+								background-color: red;
+							}
+							.bg-spin-3 {
+								background-color: gold;
+							}
+						`,
+					},
+					{
+						append: true,
+					},
+				);
+			}
 		}
 	} catch (error) {
 		console.warn('Theme registration failed:', error);

--- a/packages/samples/react/src/shares/theme.ts
+++ b/packages/samples/react/src/shares/theme.ts
@@ -1,6 +1,6 @@
 import { SelectOption } from '@public-ui/components';
 
-export const THEMES = ['default', 'ecl-ec', 'ecl-eu', 'unstyled'] as const;
+export const THEMES = ['default', 'ecl-ec', 'ecl-eu', 'kern-v2', 'unstyled'] as const;
 export type Theme = (typeof THEMES)[number];
 export type ThemeAndUnstyled = Theme | 'unstyled';
 
@@ -19,10 +19,6 @@ export type Store = {
 
 export const THEME_OPTIONS: SelectOption<ThemeAndUnstyled>[] = [
 	{
-		label: 'Unstyled (Uncolored)',
-		value: 'unstyled',
-	},
-	{
 		label: 'Default (Tested)',
 		value: 'default',
 	},
@@ -33,5 +29,13 @@ export const THEME_OPTIONS: SelectOption<ThemeAndUnstyled>[] = [
 	{
 		label: 'European Union (in progress)',
 		value: 'ecl-eu',
+	},
+	{
+		label: 'KERN-UX Standard',
+		value: 'kern-v2',
+	},
+	{
+		label: 'Unstyled (Uncolored)',
+		value: 'unstyled',
 	},
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -720,6 +720,9 @@ importers:
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.0))
+      '@kern-ux-annex/theme-kolibri':
+        specifier: 2.3.2
+        version: 2.3.2(@public-ui/components@packages+components)
       '@leanup/stack':
         specifier: 1.3.54
         version: 1.3.54(chromedriver@139.0.3)(esbuild@0.25.10)(geckodriver@5.0.0)(typescript@5.9.3)
@@ -3078,6 +3081,12 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
+
+  '@kern-ux-annex/theme-kolibri@2.3.2':
+    resolution: {integrity: sha512-ym8qkzOmPx+/MADU055tQJchcFYagc24aZv3ElAeMeZmn8q15NqLMMD9k/YoZv5JDWhUyDC/rnJ0uyYNpdrztg==}
+    engines: {pnpm: ^10}
+    peerDependencies:
+      '@public-ui/components': 3.0.7
 
   '@kessler/tableify@1.0.2':
     resolution: {integrity: sha512-e4psVV9Fe2eBfS9xK2rzQ9lE5xS4tARm7EJzDb6sVZy3F+EMyHJ67i0NdBVR9BRyQx7YhogMCbB6R1QwXuBxMg==}
@@ -16321,6 +16330,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@kern-ux-annex/theme-kolibri@2.3.2(@public-ui/components@packages+components)':
+    dependencies:
+      '@public-ui/components': link:packages/components
+
   '@kessler/tableify@1.0.2': {}
 
   '@keyv/serialize@1.1.1': {}
@@ -22987,7 +23000,7 @@ snapshots:
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3
+      jest-jasmine2: 26.6.3(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.5.2)(typescript@5.9.3))
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-util: 26.6.2
@@ -23083,7 +23096,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-jasmine2@26.6.3:
+  jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.5.2)(typescript@5.9.3)):
     dependencies:
       '@babel/traverse': 7.28.3
       '@jest/environment': 26.6.2
@@ -23104,7 +23117,11 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - ts-node
+      - utf-8-validate
 
   jest-leak-detector@26.6.2:
     dependencies:
@@ -24178,7 +24195,7 @@ snapshots:
   log4js@6.9.1:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
       flatted: 3.3.3
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -27659,7 +27676,7 @@ snapshots:
   streamroller@3.1.5:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary
- add the KERN-UX Standard theme option to the React sample and register the theme module
- install the @kern-ux-annex/theme-kolibri package and include its assets in the prepare step
- tighten typing around theme patching to satisfy lint checks and record the workspace package manager

## Testing
- pnpm --filter @public-ui/sample-react lint *(fails: existing lint errors in the sample app)*

------
https://chatgpt.com/codex/tasks/task_e_68f7243d206c832b9849e72c11634a51